### PR TITLE
FAT2-77 achievement rates

### DIFF
--- a/src/SFA.DAS.Courses.Api.AcceptanceTests/Infrastructure/DbUtilities.cs
+++ b/src/SFA.DAS.Courses.Api.AcceptanceTests/Infrastructure/DbUtilities.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using SFA.DAS.Courses.Data;
+using SFA.DAS.Courses.Domain.Entities;
 using Sector = SFA.DAS.Courses.Domain.Entities.Sector;
 using Standard = SFA.DAS.Courses.Domain.Entities.Standard;
 using LarsStandard = SFA.DAS.Courses.Domain.Entities.LarsStandard;
@@ -14,8 +15,10 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
         {
             var testSectors = GetTestSectors().ToList();
             context.Sectors.AddRange(testSectors);
+            context.SectorSubjectAreaTier2.AddRange(GetSectorSubjectAreaTier2Items());
             context.Standards.AddRange(GetValidTestStandards());
             context.Standards.AddRange(GetInValidTestStandards());
+            
             context.SaveChanges();
         }
 
@@ -23,9 +26,31 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
         {
             context.Standards.RemoveRange(context.Standards.ToList());
             context.Sectors.RemoveRange(context.Sectors.ToList());
+            context.SectorSubjectAreaTier2.RemoveRange(context.SectorSubjectAreaTier2.ToList());
             context.SaveChanges();
         }
 
+        public static IEnumerable<SectorSubjectAreaTier2> GetSectorSubjectAreaTier2Items()
+        {
+            return new List<SectorSubjectAreaTier2>
+            {
+                new SectorSubjectAreaTier2
+                {
+                    EffectiveFrom = DateTime.Today,
+                    SectorSubjectAreaTier2Desc = "Test Sector",
+                    SectorSubjectAreaTier2 = 1m,
+                    Name = "Test Sector"
+                },
+                new SectorSubjectAreaTier2
+                {
+                    EffectiveFrom = DateTime.Today,
+                    SectorSubjectAreaTier2Desc = "Test Sector 2",
+                    SectorSubjectAreaTier2 = 1.1m,
+                    Name = "Test Sector 2"
+                }
+            };
+        }
+        
         public static IEnumerable<Sector> GetTestSectors()
         {
             return new List<Sector>
@@ -51,6 +76,7 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
         public static IEnumerable<Standard> GetValidTestStandards()
         {
             var sectors = GetTestSectors().ToList();
+            var subjectSectorArea = GetSectorSubjectAreaTier2Items().ToList();
             return new List<Standard>
             {
                 new Standard
@@ -65,7 +91,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 1
+                        StandardId = 1,
+                        SectorSubjectAreaTier2 = 1m
                     }
                 },
                 new Standard
@@ -80,7 +107,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 2
+                        StandardId = 2,
+                        SectorSubjectAreaTier2 = 1m
                     }
                 },
                 new Standard
@@ -95,7 +123,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 3
+                        StandardId = 3,
+                        SectorSubjectAreaTier2 = 1.1m
                     }
                 },
                 new Standard
@@ -110,7 +139,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 4
+                        StandardId = 4,
+                        SectorSubjectAreaTier2 = 1.1m
                     }
                 },
                 new Standard
@@ -125,7 +155,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 5
+                        StandardId = 5,
+                        SectorSubjectAreaTier2 = 1m
                     }
                 },
                 new Standard
@@ -140,7 +171,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 6
+                        StandardId = 6,
+                        SectorSubjectAreaTier2 = 1.1m
                     }
                 },
                 new Standard
@@ -155,7 +187,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(-1),
                         LastDateStarts = null,
-                        StandardId = 7
+                        StandardId = 7,
+                        SectorSubjectAreaTier2 = 1m
                     }
                 }
             };
@@ -164,6 +197,7 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
         public static IEnumerable<Standard> GetInValidTestStandards()
         {
             var sectors = GetTestSectors().ToList();
+            var subjectSectorArea = GetSectorSubjectAreaTier2Items().ToList();
             return new List<Standard>
             {
                 new Standard
@@ -177,7 +211,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     LarsStandard = new LarsStandard
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(1),
-                        StandardId = 11
+                        StandardId = 11,
+                        SectorSubjectAreaTier2 = 1m
                     }
                 },
                 new Standard
@@ -191,7 +226,8 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Infrastructure
                     LarsStandard = new LarsStandard
                     {
                         EffectiveFrom = DateTime.UtcNow.AddDays(1),
-                        StandardId = 14
+                        StandardId = 14,
+                        SectorSubjectAreaTier2 = 1m
                     }
                 }
             };

--- a/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardResponse.cs
+++ b/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardResponse.cs
@@ -19,7 +19,8 @@ namespace SFA.DAS.Courses.Api.ApiResponses
         public string CoreSkillsCount { get; set; }
         public string StandardPageUrl { get; set; }
         public string IntegratedDegree { get; set; }
-
+        public decimal SectorSubjectAreaTier2 { get ; set ; }
+        public string SectorSubjectAreaTier2Description { get ; set ; }
         public List<ApprenticeshipFundingResponse> ApprenticeshipFunding { get ; set ; }
 
         public StandardDatesResponse StandardDates { get ; set ; }
@@ -41,7 +42,9 @@ namespace SFA.DAS.Courses.Api.ApiResponses
                 StandardPageUrl = source.StandardPageUrl,
                 IntegratedDegree = source.IntegratedDegree,
                 ApprenticeshipFunding = source.ApprenticeshipFunding.Select(c=>(ApprenticeshipFundingResponse)c).ToList(),
-                StandardDates = source.StandardDates
+                StandardDates = source.StandardDates,
+                SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
+                SectorSubjectAreaTier2Description = source.SectorSubjectAreaTier2Description
             };
         }
     }

--- a/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -22,6 +22,21 @@ namespace SFA.DAS.Courses.Api.AppStart
             services.AddTransient<IStandardsImportService, StandardsImportService>();
             services.AddTransient<IStandardsService, StandardsService>();
             services.AddTransient<IStandardsSortOrderService, StandardsSortOrderService>();
+            services.AddTransient<ISectorService, SectorService>();
+            services.AddTransient<ILarsPageParser, LarsPageParser>();
+            services.AddTransient<ILevelsService, LevelsService>();
+            services.AddHttpClient<ILarsDataDownloadService, LarsDataDownloadService>();
+            services.AddTransient<IZipArchiveHelper, ZipArchiveHelper>();
+            services.AddTransient<ILarsImportService, LarsImportService>();
+            services.AddTransient<IFrameworksImportService, FrameworksImportService>();
+            services.AddTransient<IJsonFileHelper, JsonFileHelper>();   
+            services.AddTransient<IFrameworksService, FrameworksService>();
+
+            AddDatabaseRegistrations(services);
+        }
+
+        private static void AddDatabaseRegistrations(IServiceCollection services)
+        {
             services.AddTransient<IStandardImportRepository, StandardImportRepository>();
             services.AddTransient<IStandardRepository, StandardRepository>();
             services.AddTransient<IImportAuditRepository, ImportAuditRepository>();
@@ -35,15 +50,8 @@ namespace SFA.DAS.Courses.Api.AppStart
             services.AddTransient<IFrameworkImportRepository, FrameworkImportRepository>();
             services.AddTransient<IFrameworkFundingImportRepository, FrameworkFundingImportRepository>();
             services.AddTransient<IFrameworkFundingRepository, FrameworkFundingRepository>();
-            services.AddTransient<ISectorService, SectorService>();
-            services.AddTransient<ILarsPageParser, LarsPageParser>();
-            services.AddTransient<ILevelsService, LevelsService>();
-            services.AddHttpClient<ILarsDataDownloadService, LarsDataDownloadService>();
-            services.AddTransient<IZipArchiveHelper, ZipArchiveHelper>();
-            services.AddTransient<ILarsImportService, LarsImportService>();
-            services.AddTransient<IFrameworksImportService, FrameworksImportService>();
-            services.AddTransient<IJsonFileHelper, JsonFileHelper>();   
-            services.AddTransient<IFrameworksService, FrameworksService>();   
+            services.AddTransient<ISectorSubjectAreaTier2Repository, SectorSubjectAreaTier2Repository>();
+            services.AddTransient<ISectorSubjectAreaTier2ImportRepository, SectorSubjectAreaTier2ImportRepository>();
         }
     }
 }

--- a/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -31,6 +31,7 @@ namespace SFA.DAS.Courses.Api.AppStart
             services.AddTransient<IFrameworksImportService, FrameworksImportService>();
             services.AddTransient<IJsonFileHelper, JsonFileHelper>();   
             services.AddTransient<IFrameworksService, FrameworksService>();
+            services.AddTransient<IQualificationSectorSubjectAreaService, QualificationSectorSubjectAreaService>();
 
             AddDatabaseRegistrations(services);
         }

--- a/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -32,7 +32,6 @@ namespace SFA.DAS.Courses.Api.AppStart
             services.AddTransient<IJsonFileHelper, JsonFileHelper>();   
             services.AddTransient<IFrameworksService, FrameworksService>();
             services.AddHttpClient<IQualificationSectorSubjectAreaService, QualificationSectorSubjectAreaService>();
-            services.AddTransient<INationalAchievementRatesPageParser, NationalAchievementRatesPageParser>();
             
             AddDatabaseRegistrations(services);
         }

--- a/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.Courses.Api.AppStart
             services.AddTransient<IFrameworksImportService, FrameworksImportService>();
             services.AddTransient<IJsonFileHelper, JsonFileHelper>();   
             services.AddTransient<IFrameworksService, FrameworksService>();
-            services.AddTransient<IQualificationSectorSubjectAreaService, QualificationSectorSubjectAreaService>();
+            services.AddHttpClient<IQualificationSectorSubjectAreaService, QualificationSectorSubjectAreaService>();
 
             AddDatabaseRegistrations(services);
         }

--- a/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
+++ b/src/SFA.DAS.Courses.Api/AppStart/AddServiceRegistrationExtension.cs
@@ -25,14 +25,15 @@ namespace SFA.DAS.Courses.Api.AppStart
             services.AddTransient<ISectorService, SectorService>();
             services.AddTransient<ILarsPageParser, LarsPageParser>();
             services.AddTransient<ILevelsService, LevelsService>();
-            services.AddHttpClient<ILarsDataDownloadService, LarsDataDownloadService>();
+            services.AddHttpClient<IDataDownloadService, DataDownloadService>();
             services.AddTransient<IZipArchiveHelper, ZipArchiveHelper>();
             services.AddTransient<ILarsImportService, LarsImportService>();
             services.AddTransient<IFrameworksImportService, FrameworksImportService>();
             services.AddTransient<IJsonFileHelper, JsonFileHelper>();   
             services.AddTransient<IFrameworksService, FrameworksService>();
             services.AddHttpClient<IQualificationSectorSubjectAreaService, QualificationSectorSubjectAreaService>();
-
+            services.AddTransient<INationalAchievementRatesPageParser, NationalAchievementRatesPageParser>();
+            
             AddDatabaseRegistrations(services);
         }
 

--- a/src/SFA.DAS.Courses.Api/Program.cs
+++ b/src/SFA.DAS.Courses.Api/Program.cs
@@ -8,6 +8,7 @@ namespace SFA.DAS.Courses.Api
     {
         public static void Main(string[] args)
         {
+            NLogBuilder.ConfigureNLog("nlog.config").GetCurrentClassLogger();
             CreateWebHostBuilder(args).Build().Run();
         }
 

--- a/src/SFA.DAS.Courses.Api/Startup.cs
+++ b/src/SFA.DAS.Courses.Api/Startup.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using MediatR;
-using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Versioning;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/SFA.DAS.Courses.Api/Startup.cs
+++ b/src/SFA.DAS.Courses.Api/Startup.cs
@@ -124,6 +124,8 @@ namespace SFA.DAS.Courses.Api
             services.AddApiVersioning(opt => {
                 opt.ApiVersionReader = new HeaderApiVersionReader("X-Version");
             });
+
+            services.AddLogging();
         }
         
 

--- a/src/SFA.DAS.Courses.Application.UnitTests/CoursesImport/Services/WhenImportingDataFromLars.cs
+++ b/src/SFA.DAS.Courses.Application.UnitTests/CoursesImport/Services/WhenImportingDataFromLars.cs
@@ -22,7 +22,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
         public async Task Then_The_Download_Path_Is_Parsed_From_The_Url_And_The_Current_File_Is_Checked_Against_The_Existing_And_If_Same_Then_No_Download(
             string filePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
             [Frozen] Mock<IApprenticeshipFundingImportRepository> apprenticeshipFundingImportRepository,
@@ -49,7 +49,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string content,
             string newFilePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             LarsImportService larsImportService)
         {
@@ -74,7 +74,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string content,
             string newFilePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             LarsImportService larsImportService)
         {
@@ -98,7 +98,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string content,
             string newFilePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<IZipArchiveHelper> zipHelper,
             LarsImportService larsImportService)
@@ -125,7 +125,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string content,
             string newFilePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<IZipArchiveHelper> zipHelper,
             LarsImportService larsImportService)
@@ -152,7 +152,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string content,
             string newFilePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<IZipArchiveHelper> zipHelper,
             LarsImportService larsImportService)
@@ -180,7 +180,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string newFilePath,
             List<QualificationItemList> apiItems,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<IQualificationSectorSubjectAreaService> qualificationSectorSubjectAreaService,
             LarsImportService larsImportService)
@@ -210,7 +210,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             string content,
             string newFilePath,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
             [Frozen] Mock<IApprenticeshipFundingImportRepository> apprenticeshipFundingImportRepository,
             [Frozen] Mock<ISectorSubjectAreaTier2ImportRepository> sectorSubjectAreaTier2ImportRepository,
@@ -250,7 +250,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             SectorSubjectAreaTier2Csv sectorSubjectAreaTier2Csv3,
             [Frozen] Mock<IQualificationSectorSubjectAreaService> qualificationSectorSubjectAreaService,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
             [Frozen] Mock<IApprenticeshipFundingImportRepository> apprenticeshipFundingImportRepository,
             [Frozen] Mock<ISectorSubjectAreaTier2ImportRepository> sectorSubjectAreaTier2ImportRepository,
@@ -317,7 +317,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             List<ApprenticeshipFundingCsv> apprenticeFundingCsv,
             List<SectorSubjectAreaTier2Csv> sectorSubjectAreaTier2Csv,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<ILarsStandardRepository> larsStandardRepository,
             [Frozen] Mock<IApprenticeshipFundingRepository> apprenticeshipFundingRepository,
             [Frozen] Mock<ISectorSubjectAreaTier2Repository> sectorSubjectAreaTier2Repository,
@@ -363,7 +363,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             List<StandardCsv> standardCsv,
             List<ApprenticeshipFundingCsv> apprenticeFundingCsv,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<ILarsStandardRepository> larsStandardRepository,
             [Frozen] Mock<IApprenticeshipFundingRepository> apprenticeshipFundingRepository,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
@@ -408,7 +408,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             List<ApprenticeshipFundingImport> apprenticeshipFundingImports,
             List<SectorSubjectAreaTier2Import> sectorSubjectAreaTier2Imports,
             [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<ILarsDataDownloadService> service,
+            [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
             [Frozen] Mock<IApprenticeshipFundingImportRepository> apprenticeshipFundingImportRepository,

--- a/src/SFA.DAS.Courses.Application.UnitTests/CoursesImport/Services/WhenImportingDataFromLars.cs
+++ b/src/SFA.DAS.Courses.Application.UnitTests/CoursesImport/Services/WhenImportingDataFromLars.cs
@@ -180,38 +180,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
                     x.ExtractModelFromCsvFileZipStream<SectorSubjectAreaTier2Csv>(It.IsAny<Stream>(),Constants.LarsSectorSubjectAreaTier2FileName), 
                 Times.Once);
         }
-
-        [Test, RecursiveMoqAutoData]
-        public async Task Then_The_QualificationSectorSubjectArea_Data_Is_Loaded(
-            string filePath,
-            string content,
-            string newFilePath,
-            List<QualificationItemList> apiItems,
-            [Frozen] Mock<ILarsPageParser> pageParser,
-            [Frozen] Mock<IDataDownloadService> service,
-            [Frozen] Mock<IImportAuditRepository> repository,
-            [Frozen] Mock<IQualificationSectorSubjectAreaService> qualificationSectorSubjectAreaService,
-            LarsImportService larsImportService)
-        {
-            //Arrange
-            service.Setup(x => x.GetFileStream(newFilePath))
-                .ReturnsAsync(new MemoryStream(Encoding.UTF8.GetBytes(content)));
-            pageParser.Setup(x => x.GetCurrentLarsDataDownloadFilePath()).ReturnsAsync(newFilePath);
-            repository.Setup(x => x.GetLastImportByType(ImportType.LarsImport))
-                .ReturnsAsync((ImportAudit)null);
-            qualificationSectorSubjectAreaService.Setup(x => x.GetEntries()).ReturnsAsync(apiItems);
-            
-            //Act
-            await larsImportService.ImportData();
-            
-            //Assert
-            qualificationSectorSubjectAreaService.Verify(x=>x.GetEntries(), Times.Once);
-            foreach (var item in apiItems)
-            {
-                qualificationSectorSubjectAreaService.Verify(x=>x.GetEntry(item.ItemHash.FirstOrDefault()), Times.Once);
-            }
-        }
-
+        
         [Test, RecursiveMoqAutoData]
         public async Task Then_The_Current_Lars_Import_Data_Is_Deleted(
             string filePath,
@@ -242,21 +211,16 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
         }
 
         [Test, RecursiveMoqAutoData]
-        public async Task Then_The_Standard_Data_Is_Loaded_Into_The_Import_Repository_Using_QualificationSectorSubjectArea_Data(
+        public async Task Then_The_Standard_Data_Is_Loaded_Into_The_Import_Repository(
             string filePath,
             string content,
             string newFilePath,
-            string sectorSubjectAreaName,
-            QualificationItem apiItem1,
-            QualificationItem apiItem2,
-            QualificationItem apiItem3,
             ApprenticeshipFundingCsv frameWorkCsv,
             List<StandardCsv> standardCsv,
             List<ApprenticeshipFundingCsv> apprenticeFundingCsv,
             SectorSubjectAreaTier2Csv sectorSubjectAreaTier2Csv1,
             SectorSubjectAreaTier2Csv sectorSubjectAreaTier2Csv2,
             SectorSubjectAreaTier2Csv sectorSubjectAreaTier2Csv3,
-            [Frozen] Mock<IQualificationSectorSubjectAreaService> qualificationSectorSubjectAreaService,
             [Frozen] Mock<ILarsPageParser> pageParser,
             [Frozen] Mock<IDataDownloadService> service,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
@@ -267,17 +231,6 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             LarsImportService larsImportService)
         {
             //Arrange
-            apiItem1.QualificationSectorSubjectArea = sectorSubjectAreaTier2Csv1.SectorSubjectAreaTier2.ToString();
-            apiItem1.Name = sectorSubjectAreaName;
-            apiItem2.QualificationSectorSubjectArea = sectorSubjectAreaTier2Csv2.SectorSubjectAreaTier2.ToString();
-            apiItem2.Name = sectorSubjectAreaName;
-            apiItem3.QualificationSectorSubjectArea = sectorSubjectAreaTier2Csv3.SectorSubjectAreaTier2.ToString();
-            apiItem3.Name = sectorSubjectAreaName;
-            qualificationSectorSubjectAreaService
-                .SetupSequence(x => x.GetEntry(It.IsAny<string>()))
-                .ReturnsAsync(apiItem1)
-                .ReturnsAsync(apiItem2)
-                .ReturnsAsync(apiItem3);
             apprenticeFundingCsv = apprenticeFundingCsv.Select(c => {c.ApprenticeshipType = "STD"; return c;}).ToList();
             frameWorkCsv.ApprenticeshipType = "FRMK"; 
             apprenticeFundingCsv.Add(frameWorkCsv);
@@ -310,9 +263,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
                 x.InsertMany(It.Is<List<ApprenticeshipFundingImport>>(c=>c.Count.Equals(apprenticeFundingCsv.Count-1))), Times.Once);
             sectorSubjectAreaTier2ImportRepository.Verify(x=>
                 x.InsertMany(It.Is<List<SectorSubjectAreaTier2Import>>(c=>
-                    c.Count.Equals(3) 
-                    && c.TrueForAll(v=>v.Name.Equals(sectorSubjectAreaName))
-                    )), Times.Once); 
+                    c.Count.Equals(3))), Times.Once); 
 
         }
         

--- a/src/SFA.DAS.Courses.Application.UnitTests/CoursesImport/Services/WhenImportingDataFromLars.cs
+++ b/src/SFA.DAS.Courses.Application.UnitTests/CoursesImport/Services/WhenImportingDataFromLars.cs
@@ -26,6 +26,10 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             [Frozen] Mock<IImportAuditRepository> repository,
             [Frozen] Mock<ILarsStandardImportRepository> larsStandardImportRepository,
             [Frozen] Mock<IApprenticeshipFundingImportRepository> apprenticeshipFundingImportRepository,
+            [Frozen] Mock<ILarsStandardRepository> larsStandardRepository,
+            [Frozen] Mock<IApprenticeshipFundingRepository> apprenticeshipFundingRepository,
+            [Frozen] Mock<ISectorSubjectAreaTier2Repository> sectorSubjectAreaRepository,
+            [Frozen] Mock<ISectorSubjectAreaTier2ImportRepository> sectorSubjectAreaImportRepository,
             LarsImportService larsImportService)
         {
             //Arrange
@@ -41,6 +45,10 @@ namespace SFA.DAS.Courses.Application.UnitTests.CoursesImport.Services
             service.Verify(x=>x.GetFileStream(It.IsAny<string>()), Times.Never);
             larsStandardImportRepository.Verify(x=>x.DeleteAll(), Times.Never);
             apprenticeshipFundingImportRepository.Verify(x=>x.DeleteAll(), Times.Never);
+            sectorSubjectAreaImportRepository.Verify(x=>x.DeleteAll(), Times.Never);
+            larsStandardRepository.Verify(x=>x.DeleteAll(), Times.Never);
+            apprenticeshipFundingRepository.Verify(x=>x.DeleteAll(), Times.Never);
+            sectorSubjectAreaRepository.Verify(x=>x.DeleteAll(), Times.Never);
         }
         
         [Test, RecursiveMoqAutoData]

--- a/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
+++ b/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
         private readonly LarsImportStaging _larsImportStaging;
 
         public LarsImportService (ILarsPageParser larsPageParser, 
-            ILarsDataDownloadService larsDataDownloadService, 
+            IDataDownloadService dataDownloadService, 
             IImportAuditRepository importAuditRepository,
             IApprenticeshipFundingImportRepository apprenticeshipFundingImportRepository,
             ILarsStandardImportRepository larsStandardImportRepository, 
@@ -43,7 +43,7 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             _sectorSubjectAreaTier2Repository = sectorSubjectAreaTier2Repository;
             _logger = logger;
             _larsImportStaging = new LarsImportStaging(
-                larsDataDownloadService,
+                dataDownloadService,
                 zipArchiveHelper,
                 _apprenticeshipFundingImportRepository,
                 _larsStandardImportRepository,

--- a/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
+++ b/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
@@ -58,9 +58,6 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
                 var importAuditStartTime = DateTime.UtcNow;
                 
                 _logger.LogInformation("LARS Import - starting data transfer from import tables");
-                _larsStandardRepository.DeleteAll();
-                _apprenticeshipFundingRepository.DeleteAll();
-                _sectorSubjectAreaTier2Repository.DeleteAll();
                 
                 _logger.LogInformation("LARS Import - commencing");
                 var lastFilePath =
@@ -84,6 +81,10 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
 
                 await Task.WhenAll(larsStandardImports, apprenticeshipFundingImports, sectorSubjectAreaTier2Imports);
 
+                _larsStandardRepository.DeleteAll();
+                _apprenticeshipFundingRepository.DeleteAll();
+                _sectorSubjectAreaTier2Repository.DeleteAll();
+                
                 var importLarsStandardResult =
                     _larsStandardRepository.InsertMany(larsStandardImports.Result
                         .Select(c => (LarsStandard)c).ToList());

--- a/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
+++ b/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
@@ -30,7 +30,6 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             ISectorSubjectAreaTier2ImportRepository sectorSubjectAreaTier2ImportRepository,
             ISectorSubjectAreaTier2Repository sectorSubjectAreaTier2Repository,
             IZipArchiveHelper zipArchiveHelper,
-            IQualificationSectorSubjectAreaService qualificationSectorSubjectAreaService,
             ILogger<LarsImportService> logger)
         {
             _larsPageParser = larsPageParser;
@@ -48,7 +47,6 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
                 _apprenticeshipFundingImportRepository,
                 _larsStandardImportRepository,
                 _sectorSubjectAreaTier2ImportRepository,
-                qualificationSectorSubjectAreaService,
                 _logger);
         }
         public async Task ImportData()

--- a/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
+++ b/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportService.cs
@@ -19,6 +19,8 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
         private readonly ILarsStandardImportRepository _larsStandardImportRepository;
         private readonly IApprenticeshipFundingRepository _apprenticeshipFundingRepository;
         private readonly ILarsStandardRepository _larsStandardRepository;
+        private readonly ISectorSubjectAreaTier2ImportRepository _sectorSubjectAreaTier2ImportRepository;
+        private readonly ISectorSubjectAreaTier2Repository _sectorSubjectAreaTier2Repository;
         private readonly IZipArchiveHelper _zipArchiveHelper;
         private readonly ILogger<LarsImportService> _logger;
 
@@ -29,6 +31,8 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             ILarsStandardImportRepository larsStandardImportRepository, 
             IApprenticeshipFundingRepository apprenticeshipFundingRepository,
             ILarsStandardRepository larsStandardRepository,
+            ISectorSubjectAreaTier2ImportRepository sectorSubjectAreaTier2ImportRepository,
+            ISectorSubjectAreaTier2Repository sectorSubjectAreaTier2Repository,
             IZipArchiveHelper zipArchiveHelper,
             ILogger<LarsImportService> logger)
         {
@@ -39,6 +43,8 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             _larsStandardImportRepository = larsStandardImportRepository;
             _apprenticeshipFundingRepository = apprenticeshipFundingRepository;
             _larsStandardRepository = larsStandardRepository;
+            _sectorSubjectAreaTier2ImportRepository = sectorSubjectAreaTier2ImportRepository;
+            _sectorSubjectAreaTier2Repository = sectorSubjectAreaTier2Repository;
             _zipArchiveHelper = zipArchiveHelper;
             _logger = logger;
         }
@@ -69,11 +75,13 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
                 _logger.LogInformation("LARS Import - starting data transfer from import tables");
                 _larsStandardRepository.DeleteAll();
                 _apprenticeshipFundingRepository.DeleteAll();
+                _sectorSubjectAreaTier2Repository.DeleteAll();
 
                 var larsStandardImports = _larsStandardImportRepository.GetAll();
                 var apprenticeshipFundingImports = _apprenticeshipFundingImportRepository.GetAll();
+                var sectorSubjectAreaTier2Imports = _sectorSubjectAreaTier2ImportRepository.GetAll();
 
-                await Task.WhenAll(larsStandardImports, apprenticeshipFundingImports);
+                await Task.WhenAll(larsStandardImports, apprenticeshipFundingImports, sectorSubjectAreaTier2Imports);
 
                 var importLarsStandardResult =
                     _larsStandardRepository.InsertMany(larsStandardImports.Result
@@ -81,11 +89,15 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
                 var importApprenticeshipFundingResult =
                     _apprenticeshipFundingRepository.InsertMany(apprenticeshipFundingImports.Result
                         .Select(c => (ApprenticeshipFunding)c).ToList());
+                var importSectorSubjectAreaTier2Result =
+                    _sectorSubjectAreaTier2Repository.InsertMany(sectorSubjectAreaTier2Imports.Result
+                        .Select(c => (SectorSubjectAreaTier2) c).ToList());
 
-                await Task.WhenAll(importLarsStandardResult, importApprenticeshipFundingResult);
+                await Task.WhenAll(importLarsStandardResult, importApprenticeshipFundingResult, importSectorSubjectAreaTier2Result);
 
                 var rowsImported = larsStandardImports.Result.Count() +
-                                   apprenticeshipFundingImports.Result.Count();
+                                   apprenticeshipFundingImports.Result.Count() +
+                                   sectorSubjectAreaTier2Imports.Result.Count();
 
                 await _importAuditRepository.Insert(new ImportAudit(importAuditStartTime,
                     rowsImported, ImportType.LarsImport, filePath.Result));
@@ -106,9 +118,13 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             var apprenticeshipFundingCsv = _zipArchiveHelper
                 .ExtractModelFromCsvFileZipStream<ApprenticeshipFundingCsv>(content,
                     Constants.LarsApprenticeshipFundingFileName);
+            var sectorSubjectAreaTier2Csv = _zipArchiveHelper
+                .ExtractModelFromCsvFileZipStream<SectorSubjectAreaTier2Csv>(content,
+                    Constants.LarsSectorSubjectAreaTier2FileName);
 
             _larsStandardImportRepository.DeleteAll();
             _apprenticeshipFundingImportRepository.DeleteAll();
+            _sectorSubjectAreaTier2ImportRepository.DeleteAll();
 
             var larsImportResult = _larsStandardImportRepository
                 .InsertMany(standardsCsv.Select(c => (LarsStandardImport) c).ToList());
@@ -120,7 +136,11 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             var apprenticeFundingImportResult =
                 _apprenticeshipFundingImportRepository.InsertMany(filterRecords);
 
-            await Task.WhenAll(larsImportResult, apprenticeFundingImportResult);
+            var sectorSubjectAreaTier2ImportResult =
+                _sectorSubjectAreaTier2ImportRepository.InsertMany(sectorSubjectAreaTier2Csv
+                    .Select(x => (SectorSubjectAreaTier2Import) x).ToList());
+
+            await Task.WhenAll(larsImportResult, apprenticeFundingImportResult, sectorSubjectAreaTier2ImportResult);
             
             _logger.LogInformation("LARS Import - finished load into Import tables");
         }

--- a/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportStaging.cs
+++ b/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportStaging.cs
@@ -14,7 +14,7 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
 {
     internal class LarsImportStaging
     {
-        private readonly ILarsDataDownloadService _larsDataDownloadService;
+        private readonly IDataDownloadService _dataDownloadService;
         private readonly IZipArchiveHelper _zipArchiveHelper;
         private readonly IApprenticeshipFundingImportRepository _apprenticeshipFundingImportRepository;
         private readonly ILarsStandardImportRepository _larsStandardImportRepository;
@@ -24,7 +24,7 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
         private Dictionary<decimal, string> _qualificationData;
 
         public LarsImportStaging (
-            ILarsDataDownloadService larsDataDownloadService,
+            IDataDownloadService dataDownloadService,
             IZipArchiveHelper zipArchiveHelper,
             IApprenticeshipFundingImportRepository apprenticeshipFundingImportRepository,
             ILarsStandardImportRepository larsStandardImportRepository,
@@ -32,7 +32,7 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
             IQualificationSectorSubjectAreaService qualificationSectorSubjectAreaService,
             ILogger<LarsImportService> logger)
         {
-            _larsDataDownloadService = larsDataDownloadService;
+            _dataDownloadService = dataDownloadService;
             _zipArchiveHelper = zipArchiveHelper;
             _apprenticeshipFundingImportRepository = apprenticeshipFundingImportRepository;
             _larsStandardImportRepository = larsStandardImportRepository;
@@ -47,7 +47,7 @@ namespace SFA.DAS.Courses.Application.CoursesImport.Services
 
             _qualificationData = await LoadQualificationSectorSubjectAreaData();
             
-            var content = await _larsDataDownloadService.GetFileStream(filePath);
+            var content = await _dataDownloadService.GetFileStream(filePath);
 
             await InsertDataFromZipStreamToImportTables(content);
         }

--- a/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportStaging.cs
+++ b/src/SFA.DAS.Courses.Application/CoursesImport/Services/LarsImportStaging.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.Courses.Domain.Configuration;
+using SFA.DAS.Courses.Domain.Entities;
+using SFA.DAS.Courses.Domain.ImportTypes;
+using SFA.DAS.Courses.Domain.Interfaces;
+
+namespace SFA.DAS.Courses.Application.CoursesImport.Services
+{
+    internal class LarsImportStaging
+    {
+        private readonly ILarsDataDownloadService _larsDataDownloadService;
+        private readonly IZipArchiveHelper _zipArchiveHelper;
+        private readonly IApprenticeshipFundingImportRepository _apprenticeshipFundingImportRepository;
+        private readonly ILarsStandardImportRepository _larsStandardImportRepository;
+        private readonly ILogger<LarsImportService> _logger;
+        private readonly ISectorSubjectAreaTier2ImportRepository _sectorSubjectAreaTier2ImportRepository;
+        private readonly IQualificationSectorSubjectAreaService _qualificationSectorSubjectAreaService;
+        private Dictionary<decimal, string> _qualificationData;
+
+        public LarsImportStaging (
+            ILarsDataDownloadService larsDataDownloadService,
+            IZipArchiveHelper zipArchiveHelper,
+            IApprenticeshipFundingImportRepository apprenticeshipFundingImportRepository,
+            ILarsStandardImportRepository larsStandardImportRepository,
+            ISectorSubjectAreaTier2ImportRepository sectorSubjectAreaTier2ImportRepository,
+            IQualificationSectorSubjectAreaService qualificationSectorSubjectAreaService,
+            ILogger<LarsImportService> logger)
+        {
+            _larsDataDownloadService = larsDataDownloadService;
+            _zipArchiveHelper = zipArchiveHelper;
+            _apprenticeshipFundingImportRepository = apprenticeshipFundingImportRepository;
+            _larsStandardImportRepository = larsStandardImportRepository;
+            _sectorSubjectAreaTier2ImportRepository = sectorSubjectAreaTier2ImportRepository;
+            _qualificationSectorSubjectAreaService = qualificationSectorSubjectAreaService;
+            _logger = logger;
+        }
+
+        public async Task Import(string filePath)
+        {
+            _logger.LogInformation($"LARS import - starting import of {filePath}");
+
+            _qualificationData = await LoadQualificationSectorSubjectAreaData();
+            
+            var content = await _larsDataDownloadService.GetFileStream(filePath);
+
+            await InsertDataFromZipStreamToImportTables(content);
+        }
+
+        private async Task<Dictionary<decimal,string>> LoadQualificationSectorSubjectAreaData()
+        {
+            var entries = await _qualificationSectorSubjectAreaService.GetEntries();
+            
+            var dictionary = new ConcurrentDictionary<decimal, string>();
+
+            await Task.WhenAll(entries.Select(entry => GetEntry(entry, dictionary)).ToArray());
+
+            return dictionary.ToDictionary(k=>k.Key, v=>v.Value);
+        }
+
+        private async Task GetEntry(QualificationItemList entry, ConcurrentDictionary<decimal, string> dictionary)
+        {
+            var result = await _qualificationSectorSubjectAreaService.GetEntry(entry.ItemHash.FirstOrDefault());
+            decimal.TryParse(result.QualificationSectorSubjectArea, out var decimalResult);
+            dictionary.TryAdd(decimalResult, result.Name);
+        }
+
+        private async Task InsertDataFromZipStreamToImportTables(Stream content)
+        {
+            _logger.LogInformation("LARS Import - starting extract from ZIP");
+            var standardsCsv = _zipArchiveHelper
+                .ExtractModelFromCsvFileZipStream<StandardCsv>(content, Constants.LarsStandardsFileName);
+            var apprenticeshipFundingCsv = _zipArchiveHelper
+                .ExtractModelFromCsvFileZipStream<ApprenticeshipFundingCsv>(content,
+                    Constants.LarsApprenticeshipFundingFileName);
+            var sectorSubjectAreaTier2Csv = _zipArchiveHelper
+                .ExtractModelFromCsvFileZipStream<SectorSubjectAreaTier2Csv>(content,
+                    Constants.LarsSectorSubjectAreaTier2FileName);
+
+            ClearStagingTables();
+
+            var larsImportResult = _larsStandardImportRepository
+                .InsertMany(standardsCsv.Select(c => (LarsStandardImport) c).ToList());
+
+            var filterRecords = apprenticeshipFundingCsv
+                .Where(c => c.ApprenticeshipType.StartsWith("STD", StringComparison.CurrentCultureIgnoreCase))
+                .Select(c => (ApprenticeshipFundingImport) c).ToList();
+            
+            var apprenticeFundingImportResult =
+                _apprenticeshipFundingImportRepository.InsertMany(filterRecords);
+
+            var sectorSubjectAreaTier2ImportResult =
+                _sectorSubjectAreaTier2ImportRepository.InsertMany(sectorSubjectAreaTier2Csv
+                    .Select(x => new SectorSubjectAreaTier2Import().Map(x, 
+                        _qualificationData.ContainsKey(x.SectorSubjectAreaTier2) 
+                            ? _qualificationData[x.SectorSubjectAreaTier2] 
+                            : "")).ToList());
+
+            await Task.WhenAll(larsImportResult, apprenticeFundingImportResult, sectorSubjectAreaTier2ImportResult);
+            
+            _logger.LogInformation("LARS Import - finished load into Import tables");
+        }
+
+        private void ClearStagingTables()
+        {
+            _larsStandardImportRepository.DeleteAll();
+            _apprenticeshipFundingImportRepository.DeleteAll();
+            _sectorSubjectAreaTier2ImportRepository.DeleteAll();
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2ImportRepository/WhenAddingMultipleItems.cs
+++ b/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2ImportRepository/WhenAddingMultipleItems.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Courses.Data.UnitTests.DatabaseMock;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.UnitTests.Repository.SectorSubjectAreaTier2ImportRepository
+{
+    public class WhenAddingMultipleItems
+    {
+        private List<SectorSubjectAreaTier2Import> _sectorSubjectAreaTier2Imports;  
+        private Mock<ICoursesDataContext> _coursesDataContext;
+        private Data.Repository.SectorSubjectAreaTier2ImportRepository _sectorSubjectAreaTier2ImportRepository;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _sectorSubjectAreaTier2Imports = new List<SectorSubjectAreaTier2Import>
+            {
+                new SectorSubjectAreaTier2Import
+                {
+                    SectorSubjectAreaTier2 = 10.1m
+                },
+                new SectorSubjectAreaTier2Import
+                {
+                    SectorSubjectAreaTier2 = 10.2m
+                }
+            };
+            
+            _coursesDataContext = new Mock<ICoursesDataContext>();
+            _coursesDataContext.Setup(x => x.SectorSubjectAreaTier2Import).ReturnsDbSet(new List<SectorSubjectAreaTier2Import>());
+            
+            _sectorSubjectAreaTier2ImportRepository = new Data.Repository.SectorSubjectAreaTier2ImportRepository(_coursesDataContext.Object);
+        }
+
+        [Test]
+        public async Task Then_The_SectorSubjectAreaTier2Import_Items_Are_Added()
+        {
+            //Act
+            await _sectorSubjectAreaTier2ImportRepository.InsertMany(_sectorSubjectAreaTier2Imports);
+            
+            //Assert
+            _coursesDataContext.Verify(x=>x.SectorSubjectAreaTier2Import.AddRangeAsync(_sectorSubjectAreaTier2Imports, It.IsAny<CancellationToken>()), Times.Once);
+            _coursesDataContext.Verify(x=>x.SaveChanges(), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2ImportRepository/WhenDeletingAllItems.cs
+++ b/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2ImportRepository/WhenDeletingAllItems.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Courses.Data.UnitTests.DatabaseMock;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.UnitTests.Repository.SectorSubjectAreaTier2ImportRepository
+{
+    public class WhenDeletingAllItems
+    {
+        private List<SectorSubjectAreaTier2Import> _sectorSubjectAreaTier2Imports;  
+        private Mock<ICoursesDataContext> _coursesDataContext;
+        private Data.Repository.SectorSubjectAreaTier2ImportRepository _sectorSubjectAreaTier2ImportRepository;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _sectorSubjectAreaTier2Imports = new List<SectorSubjectAreaTier2Import>
+            {
+                new SectorSubjectAreaTier2Import
+                {
+                    SectorSubjectAreaTier2 = 10.1m
+                },
+                new SectorSubjectAreaTier2Import
+                {
+                    SectorSubjectAreaTier2 = 10.2m
+                }
+            };
+            
+            _coursesDataContext = new Mock<ICoursesDataContext>();
+            _coursesDataContext.Setup(x => x.SectorSubjectAreaTier2Import).ReturnsDbSet(_sectorSubjectAreaTier2Imports);
+            
+            _sectorSubjectAreaTier2ImportRepository = new Data.Repository.SectorSubjectAreaTier2ImportRepository(_coursesDataContext.Object);
+        }
+
+        [Test]
+        public void Then_The_SectorSubjectAreaTier2Import_Items_Are_Removed()
+        {
+            //Act
+            _sectorSubjectAreaTier2ImportRepository.DeleteAll();
+            
+            //Assert
+            _coursesDataContext.Verify(x=>x.SectorSubjectAreaTier2Import.RemoveRange(_coursesDataContext.Object.SectorSubjectAreaTier2Import), Times.Once);
+            _coursesDataContext.Verify(x=>x.SaveChanges(), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2ImportRepository/WhenGettingAllItems.cs
+++ b/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2ImportRepository/WhenGettingAllItems.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Courses.Data.UnitTests.DatabaseMock;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.UnitTests.Repository.SectorSubjectAreaTier2ImportRepository
+{
+    public class WhenGettingAllItems
+    {
+        private List<SectorSubjectAreaTier2Import> _sectorSubjectAreaTier2Imports;  
+        private Mock<ICoursesDataContext> _coursesDataContext;
+        private Data.Repository.SectorSubjectAreaTier2ImportRepository _sectorSubjectAreaTier2ImportRepository;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _sectorSubjectAreaTier2Imports = new List<SectorSubjectAreaTier2Import>
+            {
+                new SectorSubjectAreaTier2Import
+                {
+                    SectorSubjectAreaTier2 = 10.1m
+                },
+                new SectorSubjectAreaTier2Import
+                {
+                    SectorSubjectAreaTier2 = 10.2m
+                }
+            };
+            
+            _coursesDataContext = new Mock<ICoursesDataContext>();
+            _coursesDataContext.Setup(x => x.SectorSubjectAreaTier2Import).ReturnsDbSet(_sectorSubjectAreaTier2Imports);
+            
+            _sectorSubjectAreaTier2ImportRepository = new Data.Repository.SectorSubjectAreaTier2ImportRepository(_coursesDataContext.Object);
+        }
+
+        [Test]
+        public async Task Then_The_SectorSubjectAreaTier2Import_Items_Are_Returned()
+        {
+            //Act
+            var actual = await _sectorSubjectAreaTier2ImportRepository.GetAll();
+            
+            //Assert
+            Assert.IsNotNull(actual);
+            actual.Should().BeEquivalentTo(_sectorSubjectAreaTier2Imports);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2Repository/WhenAddingMultipleItems.cs
+++ b/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2Repository/WhenAddingMultipleItems.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Courses.Data.UnitTests.DatabaseMock;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.UnitTests.Repository.SectorSubjectAreaTier2Repository
+{
+    public class WhenAddingMultipleItems
+    {
+        private List<SectorSubjectAreaTier2> _sectorSubjectAreaTier2Items;  
+        private Mock<ICoursesDataContext> _coursesDataContext;
+        private Data.Repository.SectorSubjectAreaTier2Repository _sectorSubjectAreaTier2Repository;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _sectorSubjectAreaTier2Items = new List<SectorSubjectAreaTier2>
+            {
+                new SectorSubjectAreaTier2
+                {
+                    SectorSubjectAreaTier2 = 10.1m
+                },
+                new SectorSubjectAreaTier2
+                {
+                    SectorSubjectAreaTier2 = 10.2m
+                }
+            };
+            
+            _coursesDataContext = new Mock<ICoursesDataContext>();
+            _coursesDataContext.Setup(x => x.SectorSubjectAreaTier2).ReturnsDbSet(new List<SectorSubjectAreaTier2>());
+            
+            _sectorSubjectAreaTier2Repository = new Data.Repository.SectorSubjectAreaTier2Repository(_coursesDataContext.Object);
+        }
+
+        [Test]
+        public async Task Then_The_SectorSubjectAreaTier2_Items_Are_Added()
+        {
+            //Act
+            await _sectorSubjectAreaTier2Repository.InsertMany(_sectorSubjectAreaTier2Items);
+            
+            //Assert
+            _coursesDataContext.Verify(x=>x.SectorSubjectAreaTier2.AddRangeAsync(_sectorSubjectAreaTier2Items, It.IsAny<CancellationToken>()), Times.Once);
+            _coursesDataContext.Verify(x=>x.SaveChanges(), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2Repository/WhenDeletingAllItems.cs
+++ b/src/SFA.DAS.Courses.Data.UnitTests/Repository/SectorSubjectAreaTier2Repository/WhenDeletingAllItems.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Courses.Data.UnitTests.DatabaseMock;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.UnitTests.Repository.SectorSubjectAreaTier2Repository
+{
+    public class WhenDeletingAllItems
+    {
+        private List<SectorSubjectAreaTier2> _sectorSubjectAreaTier2s;  
+        private Mock<ICoursesDataContext> _coursesDataContext;
+        private Data.Repository.SectorSubjectAreaTier2Repository _sectorSubjectAreaTier2Repository;
+
+        [SetUp]
+        public void Arrange()
+        {
+            _sectorSubjectAreaTier2s = new List<SectorSubjectAreaTier2>
+            {
+                new SectorSubjectAreaTier2
+                {
+                    SectorSubjectAreaTier2 = 10.1m
+                },
+                new SectorSubjectAreaTier2
+                {
+                    SectorSubjectAreaTier2 = 10.2m
+                }
+            };
+            
+            _coursesDataContext = new Mock<ICoursesDataContext>();
+            _coursesDataContext.Setup(x => x.SectorSubjectAreaTier2).ReturnsDbSet(_sectorSubjectAreaTier2s);
+            
+            _sectorSubjectAreaTier2Repository = new Data.Repository.SectorSubjectAreaTier2Repository(_coursesDataContext.Object);
+        }
+
+        [Test]
+        public void Then_The_SectorSubjectAreaTier2_Items_Are_Removed()
+        {
+            //Act
+            _sectorSubjectAreaTier2Repository.DeleteAll();
+            
+            //Assert
+            _coursesDataContext.Verify(x=>x.SectorSubjectAreaTier2.RemoveRange(_coursesDataContext.Object.SectorSubjectAreaTier2), Times.Once);
+            _coursesDataContext.Verify(x=>x.SaveChanges(), Times.Once);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data/Configuration/LarsStandard.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/LarsStandard.cs
@@ -16,6 +16,7 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
             builder.Property(x => x.LastDateStarts).HasColumnName("LastDateStarts").HasColumnType("datetime").IsRequired(false);
+            builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal");
 
             builder.HasOne(c => c.Standard)
                 .WithOne(c => c.LarsStandard)

--- a/src/SFA.DAS.Courses.Data/Configuration/LarsStandard.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/LarsStandard.cs
@@ -21,7 +21,14 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.HasOne(c => c.Standard)
                 .WithOne(c => c.LarsStandard)
                 .HasForeignKey<Domain.Entities.LarsStandard>(c => c.StandardId)
-                .HasPrincipalKey<Domain.Entities.Standard>(c => c.Id).Metadata.DeleteBehavior = DeleteBehavior.Restrict;
+                .HasPrincipalKey<Domain.Entities.Standard>(c => c.Id)
+                .Metadata.DeleteBehavior = DeleteBehavior.Restrict;
+            
+            builder.HasOne(c=>c.SectorSubjectArea)
+                .WithMany(c=>c.LarsStandard)
+                .HasForeignKey(c=>c.SectorSubjectAreaTier2)
+                .HasPrincipalKey(c=>c.SectorSubjectAreaTier2)
+                .Metadata.DeleteBehavior = DeleteBehavior.Restrict;
         }
     }
 }

--- a/src/SFA.DAS.Courses.Data/Configuration/LarsStandardImport.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/LarsStandardImport.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
             builder.Property(x => x.LastDateStarts).HasColumnName("LastDateStarts").HasColumnType("datetime").IsRequired(false);
-            builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal").IsRequired(true);
+            builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal");
             
             builder.Ignore(c => c.Standard);
         }

--- a/src/SFA.DAS.Courses.Data/Configuration/LarsStandardImport.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/LarsStandardImport.cs
@@ -16,7 +16,8 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
             builder.Property(x => x.LastDateStarts).HasColumnName("LastDateStarts").HasColumnType("datetime").IsRequired(false);
-
+            builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal").IsRequired(true);
+            
             builder.Ignore(c => c.Standard);
         }
     }

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
@@ -14,6 +14,8 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.Property(x => x.SectorSubjectAreaTier2Desc).HasColumnName("SectorSubjectAreaTier2Desc").HasColumnType("varchar").HasMaxLength(500);
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
+            
+            builder.HasIndex(x => x.SectorSubjectAreaTier2).IsUnique();
         }
     }
 }

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
@@ -16,6 +16,12 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
             
+            builder.HasMany(c=>c.LarsStandard)
+                .WithOne(c=>c.SectorSubjectArea)
+                .HasForeignKey(c=>c.SectorSubjectAreaTier2)
+                .HasPrincipalKey(c=>c.SectorSubjectAreaTier2)
+                .Metadata.DeleteBehavior = DeleteBehavior.Restrict;
+            
             builder.HasIndex(x => x.SectorSubjectAreaTier2).IsUnique();
         }
     }

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace SFA.DAS.Courses.Data.Configuration
+{
+    public class SectorSubjectAreaTier2 : IEntityTypeConfiguration<Domain.Entities.SectorSubjectAreaTier2>
+    {
+        public void Configure(EntityTypeBuilder<Domain.Entities.SectorSubjectAreaTier2> builder)
+        {
+            builder.ToTable("SectorSubjectAreaTier2");
+            builder.HasKey(x => x.SectorSubjectAreaTier2);
+            
+            builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal");
+            builder.Property(x => x.SectorSubjectAreaTier2Desc).HasColumnName("SectorSubjectAreaTier2Desc").HasColumnType("varchar").HasMaxLength(500);
+            builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
+            builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.Courses.Data.Configuration
             
             builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal");
             builder.Property(x => x.SectorSubjectAreaTier2Desc).HasColumnName("SectorSubjectAreaTier2Desc").HasColumnType("varchar").HasMaxLength(500);
+            builder.Property(x => x.Name).HasColumnName("Name").HasColumnType("varchar").HasMaxLength(500);
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
             

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2Import.cs
@@ -12,6 +12,7 @@ namespace SFA.DAS.Courses.Data.Configuration
             
             builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal");
             builder.Property(x => x.SectorSubjectAreaTier2Desc).HasColumnName("SectorSubjectAreaTier2Desc").HasColumnType("varchar").HasMaxLength(500);
+            builder.Property(x => x.Name).HasColumnName("Name").HasColumnType("varchar").HasMaxLength(500).IsRequired(false);
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
             

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2Import.cs
@@ -14,6 +14,8 @@ namespace SFA.DAS.Courses.Data.Configuration
             builder.Property(x => x.SectorSubjectAreaTier2Desc).HasColumnName("SectorSubjectAreaTier2Desc").HasColumnType("varchar").HasMaxLength(500);
             builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
             builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
+            
+            builder.HasIndex(x => x.SectorSubjectAreaTier2).IsUnique();
         }
     }
 }

--- a/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Data/Configuration/SectorSubjectAreaTier2Import.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace SFA.DAS.Courses.Data.Configuration
+{
+    public class SectorSubjectAreaTier2Import : IEntityTypeConfiguration<Domain.Entities.SectorSubjectAreaTier2Import>
+    {
+        public void Configure(EntityTypeBuilder<Domain.Entities.SectorSubjectAreaTier2Import> builder)
+        {
+            builder.ToTable("SectorSubjectAreaTier2_Import");
+            builder.HasKey(x => x.SectorSubjectAreaTier2);
+            
+            builder.Property(x => x.SectorSubjectAreaTier2).HasColumnName("SectorSubjectAreaTier2").HasColumnType("decimal");
+            builder.Property(x => x.SectorSubjectAreaTier2Desc).HasColumnName("SectorSubjectAreaTier2Desc").HasColumnType("varchar").HasMaxLength(500);
+            builder.Property(x => x.EffectiveFrom).HasColumnName("EffectiveFrom").HasColumnType("datetime").IsRequired();
+            builder.Property(x => x.EffectiveTo).HasColumnName("EffectiveTo").HasColumnType("datetime").IsRequired(false);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data/CoursesDataContext.cs
+++ b/src/SFA.DAS.Courses.Data/CoursesDataContext.cs
@@ -24,6 +24,8 @@ namespace SFA.DAS.Courses.Data
         DbSet<Domain.Entities.FrameworkImport> FrameworksImport { get; set; }
         DbSet<Domain.Entities.FrameworkFunding> FrameworkFunding { get; set; }
         DbSet<Domain.Entities.FrameworkFundingImport> FrameworkFundingImport { get; set; }
+        DbSet<Domain.Entities.SectorSubjectAreaTier2> SectorSubjectAreaTier2 { get; set; }
+        DbSet<Domain.Entities.SectorSubjectAreaTier2Import> SectorSubjectAreaTier2Import { get; set; }
         int SaveChanges();
     }
     
@@ -44,6 +46,8 @@ namespace SFA.DAS.Courses.Data
         public DbSet<Domain.Entities.FrameworkImport> FrameworksImport { get; set; }
         public DbSet<Domain.Entities.FrameworkFunding> FrameworkFunding { get; set; }
         public DbSet<Domain.Entities.FrameworkFundingImport> FrameworkFundingImport { get; set; }
+        public DbSet<Domain.Entities.SectorSubjectAreaTier2> SectorSubjectAreaTier2 { get; set; }
+        public DbSet<Domain.Entities.SectorSubjectAreaTier2Import> SectorSubjectAreaTier2Import { get; set; }
 
         private readonly CoursesConfiguration _configuration;
         private readonly AzureServiceTokenProvider _azureServiceTokenProvider;
@@ -95,7 +99,8 @@ namespace SFA.DAS.Courses.Data
             modelBuilder.ApplyConfiguration(new FrameworkImport());
             modelBuilder.ApplyConfiguration(new FrameworkFunding());
             modelBuilder.ApplyConfiguration(new FrameworkFundingImport());
-            
+            modelBuilder.ApplyConfiguration(new SectorSubjectAreaTier2());
+            modelBuilder.ApplyConfiguration(new SectorSubjectAreaTier2Import());
             base.OnModelCreating(modelBuilder);
         }
     }

--- a/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2ImportRepository.cs
+++ b/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2ImportRepository.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.Repository
+{
+    public class SectorSubjectAreaTier2ImportRepository
+    {
+        private readonly ICoursesDataContext _coursesDataContext;
+        public SectorSubjectAreaTier2ImportRepository (ICoursesDataContext coursesDataContext)
+        {
+            _coursesDataContext = coursesDataContext;
+        }
+
+        public async Task<IEnumerable<SectorSubjectAreaTier2Import>> GetAll()
+        {
+            var items = await _coursesDataContext.SectorSubjectAreaTier2Import.ToListAsync();
+            return items;
+        }
+
+        public void DeleteAll()
+        {
+            _coursesDataContext.SectorSubjectAreaTier2Import.RemoveRange(_coursesDataContext.SectorSubjectAreaTier2Import);
+            _coursesDataContext.SaveChanges();
+        }
+
+        public async Task InsertMany(IEnumerable<SectorSubjectAreaTier2Import> sectorSubjectAreaTier2Imports)
+        {
+            await _coursesDataContext.SectorSubjectAreaTier2Import.AddRangeAsync(sectorSubjectAreaTier2Imports);
+            _coursesDataContext.SaveChanges();
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2ImportRepository.cs
+++ b/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2ImportRepository.cs
@@ -2,10 +2,11 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using SFA.DAS.Courses.Domain.Entities;
+using SFA.DAS.Courses.Domain.Interfaces;
 
 namespace SFA.DAS.Courses.Data.Repository
 {
-    public class SectorSubjectAreaTier2ImportRepository
+    public class SectorSubjectAreaTier2ImportRepository : ISectorSubjectAreaTier2ImportRepository
     {
         private readonly ICoursesDataContext _coursesDataContext;
         public SectorSubjectAreaTier2ImportRepository (ICoursesDataContext coursesDataContext)

--- a/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2Repository.cs
+++ b/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2Repository.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Data.Repository
+{
+    public class SectorSubjectAreaTier2Repository
+    {
+        private readonly ICoursesDataContext _coursesDataContext;
+
+        public SectorSubjectAreaTier2Repository (ICoursesDataContext coursesDataContext)
+        {
+            _coursesDataContext = coursesDataContext;
+        }
+
+        public void DeleteAll()
+        {
+            _coursesDataContext.SectorSubjectAreaTier2.RemoveRange(_coursesDataContext.SectorSubjectAreaTier2);
+            _coursesDataContext.SaveChanges();
+        }
+
+        public async Task InsertMany(IEnumerable<SectorSubjectAreaTier2> sectorSubjectAreaTier2Items)
+        {
+            await _coursesDataContext.SectorSubjectAreaTier2.AddRangeAsync(sectorSubjectAreaTier2Items);
+            _coursesDataContext.SaveChanges();
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2Repository.cs
+++ b/src/SFA.DAS.Courses.Data/Repository/SectorSubjectAreaTier2Repository.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using SFA.DAS.Courses.Domain.Entities;
+using SFA.DAS.Courses.Domain.Interfaces;
 
 namespace SFA.DAS.Courses.Data.Repository
 {
-    public class SectorSubjectAreaTier2Repository
+    public class SectorSubjectAreaTier2Repository : ISectorSubjectAreaTier2Repository
     {
         private readonly ICoursesDataContext _coursesDataContext;
 

--- a/src/SFA.DAS.Courses.Database/SFA.DAS.Courses.Database.sqlproj
+++ b/src/SFA.DAS.Courses.Database/SFA.DAS.Courses.Database.sqlproj
@@ -69,6 +69,8 @@
     <Build Include="Tables\LarsStandard.sql" />
     <Build Include="Tables\LarsStandard_Import.sql" />
     <Build Include="Tables\Sector.sql" />
+    <Build Include="Tables\SectorSubjectAreaTier2.sql" />
+    <Build Include="Tables\SectorSubjectAreaTier2_Import.sql" />
     <Build Include="Tables\Sector_Import.sql" />
     <Build Include="Tables\Standard.sql" />
     <Build Include="Tables\Standard_Import.sql" />

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
@@ -10,6 +10,6 @@
 )
 GO
 
-CREATE NONCLUSTERED INDEX [IDX_LarsStandard_StandardId] ON [dbo].[Standard] (StandardId) 
+CREATE NONCLUSTERED INDEX [IDX_LarsStandard_StandardId] ON [dbo].[LarsStandard] (StandardId) 
 INCLUDE (Id,Version,EffectiveFrom,EffectiveTo,  LastDateStarts, SectorSubjectAreaTier2) WITH (ONLINE = ON) 
 GO 

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
@@ -6,7 +6,7 @@
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL,
 	[LastDateStarts] DATETIME NULL,
-	[SectorSubjectAreaTier2] DECIMAL NULL,
+	[SectorSubjectAreaTier2] decimal(10,4) NULL,
 )
 GO
 

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
@@ -6,5 +6,10 @@
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL,
 	[LastDateStarts] DATETIME NULL,
+	[SectorSubjectAreaTier2] DECIMAL NULL,
 )
 GO
+
+CREATE NONCLUSTERED INDEX [IDX_LarsStandard_StandardId] ON [dbo].[Standard] (StandardId) 
+INCLUDE (Id,Version,EffectiveFrom,EffectiveTo,  LastDateStarts, SectorSubjectAreaTier2) WITH (ONLINE = ON) 
+GO 

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard.sql
@@ -6,7 +6,7 @@
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL,
 	[LastDateStarts] DATETIME NULL,
-	[SectorSubjectAreaTier2] decimal(10,4) NULL,
+	[SectorSubjectAreaTier2] decimal(10,4) NOT NULL DEFAULT(0.0),
 )
 GO
 

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard_Import.sql
@@ -6,5 +6,6 @@
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL,
 	[LastDateStarts] DATETIME NULL,
+	[SectorSubjectAreaTier2] DECIMAL NULL,
 )
 GO

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard_Import.sql
@@ -6,6 +6,6 @@
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL,
 	[LastDateStarts] DATETIME NULL,
-	[SectorSubjectAreaTier2] DECIMAL NULL,
+	[SectorSubjectAreaTier2] decimal(10,4) NULL,
 )
 GO

--- a/src/SFA.DAS.Courses.Database/Tables/LarsStandard_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/LarsStandard_Import.sql
@@ -6,6 +6,6 @@
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL,
 	[LastDateStarts] DATETIME NULL,
-	[SectorSubjectAreaTier2] decimal(10,4) NULL,
+	[SectorSubjectAreaTier2] decimal(10,4) NOT NULL DEFAULT (0.0),
 )
 GO

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
@@ -2,7 +2,8 @@
 (
 	[SectorSubjectAreaTier2] decimal NOT NULL PRIMARY KEY,
 	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
-	[EffectiveFrom] DATETIME NOT NULL
+	[EffectiveFrom] DATETIME NOT NULL,
+	[EffectiveTo] DATETIME NULL
 )
 GO
 

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE [dbo].[SectorSubjectAreaTier2]
 (
-	[SectorSubjectAreaTier2] decimal NOT NULL PRIMARY KEY,
+	[SectorSubjectAreaTier2] decimal(10,4) NOT NULL PRIMARY KEY,
 	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
@@ -1,0 +1,9 @@
+﻿CREATE TABLE [dbo].[SectorSubjectAreaTier2]
+(
+	[SectorSubjectAreaTier2] decimal NOT NULL PRIMARY KEY,
+	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
+	[EffectiveFrom] DATETIME NOT NULL
+)
+GO
+
+ 

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2.sql
@@ -2,6 +2,7 @@
 (
 	[SectorSubjectAreaTier2] decimal(10,4) NOT NULL PRIMARY KEY,
 	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
+	[Name] VARCHAR(500) NOT NULL,
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL
 )

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
@@ -1,0 +1,9 @@
+﻿CREATE TABLE [dbo].[SectorSubjectAreaTier2_Import]
+(
+	[SectorSubjectAreaTier2] decimal NOT NULL PRIMARY KEY,
+	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
+	[EffectiveFrom] DATETIME NOT NULL
+)
+GO
+
+ 

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
@@ -2,7 +2,8 @@
 (
 	[SectorSubjectAreaTier2] decimal NOT NULL PRIMARY KEY,
 	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
-	[EffectiveFrom] DATETIME NOT NULL
+	[EffectiveFrom] DATETIME NOT NULL,
+	[EffectiveTo] DATETIME NULL
 )
 GO
 

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
@@ -2,6 +2,7 @@
 (
 	[SectorSubjectAreaTier2] decimal(10,4) NOT NULL PRIMARY KEY,
 	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
+	[Name] VARCHAR(500) NULL,
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL
 )

--- a/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
+++ b/src/SFA.DAS.Courses.Database/Tables/SectorSubjectAreaTier2_Import.sql
@@ -1,6 +1,6 @@
 ﻿CREATE TABLE [dbo].[SectorSubjectAreaTier2_Import]
 (
-	[SectorSubjectAreaTier2] decimal NOT NULL PRIMARY KEY,
+	[SectorSubjectAreaTier2] decimal(10,4) NOT NULL PRIMARY KEY,
 	[SectorSubjectAreaTier2Desc] VARCHAR(500) NOT NULL,
 	[EffectiveFrom] DATETIME NOT NULL,
 	[EffectiveTo] DATETIME NULL

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Courses/WhenCastingToStandardDatesFromEntity.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Courses/WhenCastingToStandardDatesFromEntity.cs
@@ -19,6 +19,7 @@ namespace SFA.DAS.Courses.Domain.UnitTests.Courses
                 .Excluding(c=>c.StandardId)
                 .Excluding(c=>c.Version)
                 .Excluding(c=>c.Standard)
+                .Excluding(c=>c.SectorSubjectAreaTier2)
             );
         }
     }

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Courses/WhenCastingToStandardDatesFromEntity.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Courses/WhenCastingToStandardDatesFromEntity.cs
@@ -19,6 +19,7 @@ namespace SFA.DAS.Courses.Domain.UnitTests.Courses
                 .Excluding(c=>c.StandardId)
                 .Excluding(c=>c.Version)
                 .Excluding(c=>c.Standard)
+                .Excluding(c=>c.SectorSubjectArea)
                 .Excluding(c=>c.SectorSubjectAreaTier2)
             );
         }

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Courses/WhenCastingToStandardFromEntity.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Courses/WhenCastingToStandardFromEntity.cs
@@ -25,6 +25,8 @@ namespace SFA.DAS.Courses.Domain.UnitTests.Courses
             response.Route.Should().Be(source.Sector.Route);
             response.ApprenticeshipFunding.Should().NotBeNull();
             response.StandardDates.Should().NotBeNull();
+            response.SectorSubjectAreaTier2.Should().Be(source.LarsStandard.SectorSubjectArea.SectorSubjectAreaTier2);
+            response.SectorSubjectAreaTier2Description.Should().Be(source.LarsStandard.SectorSubjectArea.Name);
         }
     }
 }

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import.cs
@@ -1,0 +1,19 @@
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.Courses.Domain.Entities;
+using SFA.DAS.Courses.Domain.ImportTypes;
+
+namespace SFA.DAS.Courses.Domain.UnitTests.Entities
+{
+    public class WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import
+    {
+        [Test, AutoData]
+        public void Then_The_Fields_Are_Correctly_Mapped(SectorSubjectAreaTier2Csv source)
+        {
+            var actual = (SectorSubjectAreaTier2Import) source;
+            
+            actual.Should().BeEquivalentTo(source);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import.cs
@@ -11,10 +11,10 @@ namespace SFA.DAS.Courses.Domain.UnitTests.Entities
         [Test, AutoData]
         public void Then_The_Fields_Are_Correctly_Mapped(SectorSubjectAreaTier2Csv source, string name)
         {
-            var actual = new SectorSubjectAreaTier2Import().Map(source, name);
+            var actual = (SectorSubjectAreaTier2Import)source;
             
             actual.Should().BeEquivalentTo(source);
-            actual.Name.Should().Be(name);
+            actual.Name.Should().Be(source.SectorSubjectAreaTier2Desc);
         }
     }
 }

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import.cs
@@ -9,11 +9,12 @@ namespace SFA.DAS.Courses.Domain.UnitTests.Entities
     public class WhenCastingFromSectorSubjectAreaTier2CsvToSectorSubjectAreaTier2Import
     {
         [Test, AutoData]
-        public void Then_The_Fields_Are_Correctly_Mapped(SectorSubjectAreaTier2Csv source)
+        public void Then_The_Fields_Are_Correctly_Mapped(SectorSubjectAreaTier2Csv source, string name)
         {
-            var actual = (SectorSubjectAreaTier2Import) source;
+            var actual = new SectorSubjectAreaTier2Import().Map(source, name);
             
             actual.Should().BeEquivalentTo(source);
+            actual.Name.Should().Be(name);
         }
     }
 }

--- a/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2ImportToSectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Domain.UnitTests/Entities/WhenCastingFromSectorSubjectAreaTier2ImportToSectorSubjectAreaTier2.cs
@@ -1,0 +1,18 @@
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Domain.UnitTests.Entities
+{
+    public class WhenCastingFromSectorSubjectAreaTier2ImportToSectorSubjectAreaTier2
+    {
+        [Test, AutoData]
+        public void Then_The_Fields_Are_Correctly_Mapped(SectorSubjectAreaTier2Import source)
+        {
+            var actual = (SectorSubjectAreaTier2) source;
+            
+            actual.Should().BeEquivalentTo(source);
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/Configuration/Constants.cs
+++ b/src/SFA.DAS.Courses.Domain/Configuration/Constants.cs
@@ -7,5 +7,6 @@ namespace SFA.DAS.Courses.Domain.Configuration
         public static string LarsDownloadPageUrl => $"{LarsBasePageUrl}/Learning%20Aims/Downloads/Pages/default.aspx";
         public static string LarsStandardsFileName => "Standard.csv";
         public static string LarsApprenticeshipFundingFileName => "ApprenticeshipFunding.csv";
+        public static string LarsSectorSubjectAreaTier2FileName => "SectorSubjectAreaTier2.csv";
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Configuration/Constants.cs
+++ b/src/SFA.DAS.Courses.Domain/Configuration/Constants.cs
@@ -3,6 +3,7 @@ namespace SFA.DAS.Courses.Domain.Configuration
     public static class Constants
     {
         public static string InstituteOfApprenticeshipsStandardsUrl => "https://www.instituteforapprenticeships.org/api/apprenticeshipstandards/";
+        public static string QualificationSectorSubjectAreaUrl => "http://qualification-sector-subject-area.register.gov.uk/";
         public static string LarsBasePageUrl => "https://hub.fasst.org.uk";
         public static string LarsDownloadPageUrl => $"{LarsBasePageUrl}/Learning%20Aims/Downloads/Pages/default.aspx";
         public static string LarsStandardsFileName => "Standard.csv";

--- a/src/SFA.DAS.Courses.Domain/Courses/Standard.cs
+++ b/src/SFA.DAS.Courses.Domain/Courses/Standard.cs
@@ -21,6 +21,8 @@ namespace SFA.DAS.Courses.Domain.Courses
         public IEnumerable<ApprenticeshipFunding> ApprenticeshipFunding { get ; set ; }
 
         public StandardDates StandardDates { get ; set ; }
+        public decimal SectorSubjectAreaTier2 { get ; set ; }
+        public string SectorSubjectAreaTier2Description { get ; set ; }
 
         public static implicit operator Standard(Entities.Standard source)
         {
@@ -39,7 +41,9 @@ namespace SFA.DAS.Courses.Domain.Courses
                 StandardPageUrl = source.StandardPageUrl,
                 IntegratedDegree = source.IntegratedDegree,
                 ApprenticeshipFunding = source.ApprenticeshipFunding.Select(c=>(ApprenticeshipFunding)c).ToList(),
-                StandardDates = source.LarsStandard
+                StandardDates = source.LarsStandard,
+                SectorSubjectAreaTier2 = source.LarsStandard.SectorSubjectArea.SectorSubjectAreaTier2,
+                SectorSubjectAreaTier2Description = source.LarsStandard.SectorSubjectArea.Name
             };
         }
     }

--- a/src/SFA.DAS.Courses.Domain/Entities/LarsStandard.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/LarsStandard.cs
@@ -11,7 +11,8 @@ namespace SFA.DAS.Courses.Domain.Entities
                 EffectiveFrom = larsStandardImport.EffectiveFrom,
                 EffectiveTo = larsStandardImport.EffectiveTo,
                 StandardId = larsStandardImport.StandardId,
-                LastDateStarts = larsStandardImport.LastDateStarts
+                LastDateStarts = larsStandardImport.LastDateStarts,
+                SectorSubjectAreaTier2 = larsStandardImport.SectorSubjectAreaTier2
             };
         }
     }

--- a/src/SFA.DAS.Courses.Domain/Entities/LarsStandard.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/LarsStandard.cs
@@ -2,6 +2,7 @@ namespace SFA.DAS.Courses.Domain.Entities
 {
     public class LarsStandard : LarsStandardBase
     {
+        public virtual SectorSubjectAreaTier2 SectorSubjectArea { get; set; }
         public static implicit operator LarsStandard(LarsStandardImport larsStandardImport)
         {
             return new LarsStandard

--- a/src/SFA.DAS.Courses.Domain/Entities/LarsStandardBase.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/LarsStandardBase.cs
@@ -10,6 +10,7 @@ namespace SFA.DAS.Courses.Domain.Entities
         public DateTime EffectiveFrom { get; set; }
         public DateTime? EffectiveTo { get; set; }
         public DateTime? LastDateStarts { get; set; }
+        public decimal SectorSubjectAreaTier2 { get; set; }
         public virtual Standard Standard { get; set; }
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Entities/LarsStandardImport.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/LarsStandardImport.cs
@@ -14,7 +14,8 @@ namespace SFA.DAS.Courses.Domain.Entities
                 EffectiveFrom = standardCsv.EffectiveFrom,
                 EffectiveTo = standardCsv.EffectiveTo,
                 LastDateStarts = standardCsv.LastDateStarts,
-                StandardId = standardCsv.StandardCode
+                StandardId = standardCsv.StandardCode,
+                SectorSubjectAreaTier2 = standardCsv.SectorSubjectAreaTier2
             };
         }
     }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
@@ -1,0 +1,7 @@
+namespace SFA.DAS.Courses.Domain.Entities
+{
+    public class SectorSubjectAreaTier2 : SectorSubjectAreaTier2Base
+    {
+        
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
@@ -9,7 +9,8 @@ namespace SFA.DAS.Courses.Domain.Entities
                 SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
                 SectorSubjectAreaTier2Desc = source.SectorSubjectAreaTier2Desc,
                 EffectiveFrom = source.EffectiveFrom,
-                EffectiveTo = source.EffectiveTo
+                EffectiveTo = source.EffectiveTo,
+                Name = source.Name
             };
         }
     }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SFA.DAS.Courses.Domain.Entities
 {
     public class SectorSubjectAreaTier2 : SectorSubjectAreaTier2Base
@@ -13,5 +15,7 @@ namespace SFA.DAS.Courses.Domain.Entities
                 Name = source.Name
             };
         }
+
+        public virtual ICollection<LarsStandard> LarsStandard { get ; set ; }
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2.cs
@@ -2,6 +2,15 @@ namespace SFA.DAS.Courses.Domain.Entities
 {
     public class SectorSubjectAreaTier2 : SectorSubjectAreaTier2Base
     {
-        
+        public static implicit operator SectorSubjectAreaTier2(SectorSubjectAreaTier2Import source)
+        {
+            return new SectorSubjectAreaTier2
+            {
+                SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
+                SectorSubjectAreaTier2Desc = source.SectorSubjectAreaTier2Desc,
+                EffectiveFrom = source.EffectiveFrom,
+                EffectiveTo = source.EffectiveTo
+            };
+        }
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Base.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Base.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace SFA.DAS.Courses.Domain.Entities
+{
+    public class SectorSubjectAreaTier2Base
+    {
+        public decimal SectorSubjectAreaTier2 { get; set; }
+        public string SectorSubjectAreaTier2Desc { get; set; }
+        public DateTime EffectiveFrom { get; set; }
+        public DateTime? EffectiveTo { get; set; }
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Base.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Base.cs
@@ -6,6 +6,7 @@ namespace SFA.DAS.Courses.Domain.Entities
     {
         public decimal SectorSubjectAreaTier2 { get; set; }
         public string SectorSubjectAreaTier2Desc { get; set; }
+        public string Name { get; set; }
         public DateTime EffectiveFrom { get; set; }
         public DateTime? EffectiveTo { get; set; }
     }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
@@ -1,0 +1,7 @@
+namespace SFA.DAS.Courses.Domain.Entities
+{
+    public class SectorSubjectAreaTier2Import : SectorSubjectAreaTier2Base
+    {
+        
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
@@ -4,7 +4,7 @@ namespace SFA.DAS.Courses.Domain.Entities
 {
     public class SectorSubjectAreaTier2Import : SectorSubjectAreaTier2Base
     {
-        public SectorSubjectAreaTier2Import Map(SectorSubjectAreaTier2Csv source, string name)
+        public static implicit operator SectorSubjectAreaTier2Import(SectorSubjectAreaTier2Csv source)
         {
             return new SectorSubjectAreaTier2Import
             {
@@ -12,7 +12,7 @@ namespace SFA.DAS.Courses.Domain.Entities
                 SectorSubjectAreaTier2Desc = source.SectorSubjectAreaTier2Desc,
                 EffectiveFrom = source.EffectiveFrom,
                 EffectiveTo = source.EffectiveTo,
-                Name = name
+                Name = source.SectorSubjectAreaTier2Desc
             };
         }
     }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
@@ -1,7 +1,18 @@
+using SFA.DAS.Courses.Domain.ImportTypes;
+
 namespace SFA.DAS.Courses.Domain.Entities
 {
     public class SectorSubjectAreaTier2Import : SectorSubjectAreaTier2Base
     {
-        
+        public static implicit operator SectorSubjectAreaTier2Import(SectorSubjectAreaTier2Csv source)
+        {
+            return new SectorSubjectAreaTier2Import
+            {
+                SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
+                SectorSubjectAreaTier2Desc = source.SectorSubjectAreaTier2Desc,
+                EffectiveFrom = source.EffectiveFrom,
+                EffectiveTo = source.EffectiveTo
+            };
+        }
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
+++ b/src/SFA.DAS.Courses.Domain/Entities/SectorSubjectAreaTier2Import.cs
@@ -4,14 +4,15 @@ namespace SFA.DAS.Courses.Domain.Entities
 {
     public class SectorSubjectAreaTier2Import : SectorSubjectAreaTier2Base
     {
-        public static implicit operator SectorSubjectAreaTier2Import(SectorSubjectAreaTier2Csv source)
+        public SectorSubjectAreaTier2Import Map(SectorSubjectAreaTier2Csv source, string name)
         {
             return new SectorSubjectAreaTier2Import
             {
                 SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
                 SectorSubjectAreaTier2Desc = source.SectorSubjectAreaTier2Desc,
                 EffectiveFrom = source.EffectiveFrom,
-                EffectiveTo = source.EffectiveTo
+                EffectiveTo = source.EffectiveTo,
+                Name = name
             };
         }
     }

--- a/src/SFA.DAS.Courses.Domain/ImportTypes/QualificationItemList.cs
+++ b/src/SFA.DAS.Courses.Domain/ImportTypes/QualificationItemList.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace SFA.DAS.Courses.Domain.ImportTypes
+{
+    public class QualificationItemList
+    {
+        [JsonProperty("item-hash")]
+        public List<string> ItemHash { get; set; }
+    }
+    
+    public class QualificationItem
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("parent-qualification-sector-subject-area")]
+        public string ParentQualificationSectorSubjectArea { get; set; }
+
+        [JsonProperty("qualification-sector-subject-area")]
+        public string QualificationSectorSubjectArea { get; set; }
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/ImportTypes/SectorSubjectAreaTier2Csv.cs
+++ b/src/SFA.DAS.Courses.Domain/ImportTypes/SectorSubjectAreaTier2Csv.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace SFA.DAS.Courses.Domain.ImportTypes
+{
+    public class SectorSubjectAreaTier2Csv
+    {
+        public decimal SectorSubjectAreaTier2 { get; set; }
+        public string SectorSubjectAreaTier2Desc { get; set; }
+        public DateTime EffectiveFrom { get; set; }
+        public DateTime? EffectiveTo { get; set; }
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/ImportTypes/StandardCsv.cs
+++ b/src/SFA.DAS.Courses.Domain/ImportTypes/StandardCsv.cs
@@ -9,5 +9,6 @@ namespace SFA.DAS.Courses.Domain.ImportTypes
         public DateTime EffectiveFrom { get; set; }
         public DateTime? EffectiveTo { get; set; }
         public DateTime? LastDateStarts { get; set; }
+        public decimal SectorSubjectAreaTier2 { get; set; }
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Interfaces/IDataDownloadService.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/IDataDownloadService.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace SFA.DAS.Courses.Domain.Interfaces
 {
-    public interface ILarsDataDownloadService
+    public interface IDataDownloadService
     {
         Task<Stream> GetFileStream(string downloadPath);
     }

--- a/src/SFA.DAS.Courses.Domain/Interfaces/IQualificationSectorSubjectAreaService.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/IQualificationSectorSubjectAreaService.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Courses.Domain.ImportTypes;
+
+namespace SFA.DAS.Courses.Domain.Interfaces
+{
+    public interface IQualificationSectorSubjectAreaService
+    {
+        Task<IEnumerable<QualificationItem>> GetEntry(string itemHash);
+        Task<IEnumerable<QualificationItemList>> GetEntries();
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/Interfaces/IQualificationSectorSubjectAreaService.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/IQualificationSectorSubjectAreaService.cs
@@ -6,7 +6,7 @@ namespace SFA.DAS.Courses.Domain.Interfaces
 {
     public interface IQualificationSectorSubjectAreaService
     {
-        Task<IEnumerable<QualificationItem>> GetEntry(string itemHash);
+        Task<QualificationItem> GetEntry(string itemHash);
         Task<IEnumerable<QualificationItemList>> GetEntries();
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Interfaces/ISectorSubjectAreaTier2ImportRepository.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/ISectorSubjectAreaTier2ImportRepository.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Domain.Interfaces
+{
+    public interface ISectorSubjectAreaTier2ImportRepository
+    {
+        Task<IEnumerable<SectorSubjectAreaTier2Import>> GetAll();
+        void DeleteAll();
+        Task InsertMany(IEnumerable<SectorSubjectAreaTier2Import> sectorSubjectAreaTier2Imports);
+    }
+}

--- a/src/SFA.DAS.Courses.Domain/Interfaces/ISectorSubjectAreaTier2Repository.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/ISectorSubjectAreaTier2Repository.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Courses.Domain.Entities;
+
+namespace SFA.DAS.Courses.Domain.Interfaces
+{
+    public interface ISectorSubjectAreaTier2Repository
+    {
+        void DeleteAll();
+        Task InsertMany(IEnumerable<SectorSubjectAreaTier2> sectorSubjectAreaTier2Items);
+    }
+}

--- a/src/SFA.DAS.Courses.Infrastructure.UnitTests/Api/WhenGettingDataFromLars.cs
+++ b/src/SFA.DAS.Courses.Infrastructure.UnitTests/Api/WhenGettingDataFromLars.cs
@@ -29,7 +29,7 @@ namespace SFA.DAS.Courses.Infrastructure.UnitTests.Api
             var downloadUrl = "https://test";
             var httpMessageHandler = MessageHandler.SetupMessageHandlerMock(response, new Uri(downloadUrl));
             var client = new HttpClient(httpMessageHandler.Object);
-            var larsDataDownloadService = new LarsDataDownloadService(client);
+            var larsDataDownloadService = new DataDownloadService(client);
 
             //Act
             var actual = await larsDataDownloadService.GetFileStream(downloadUrl);
@@ -52,7 +52,7 @@ namespace SFA.DAS.Courses.Infrastructure.UnitTests.Api
             var downloadUrl = "https://test.zip";
             var httpMessageHandler = MessageHandler.SetupMessageHandlerMock(response, new Uri(downloadUrl));
             var client = new HttpClient(httpMessageHandler.Object);
-            var larsDataDownloadService = new LarsDataDownloadService(client);
+            var larsDataDownloadService = new DataDownloadService(client);
 
             //Act Assert
             Assert.ThrowsAsync<HttpRequestException>(() => larsDataDownloadService.GetFileStream(downloadUrl));

--- a/src/SFA.DAS.Courses.Infrastructure.UnitTests/Api/WhenGettingDataFromQualificationSectorSubjectAreaApi.cs
+++ b/src/SFA.DAS.Courses.Infrastructure.UnitTests/Api/WhenGettingDataFromQualificationSectorSubjectAreaApi.cs
@@ -52,12 +52,12 @@ namespace SFA.DAS.Courses.Infrastructure.UnitTests.Api
         [Test, AutoData]
         public async Task Then_The_Endpoint_Is_Called_And_An_Item_Detail_Is_Returned(
             string itemHash,
-            List<Domain.ImportTypes.QualificationItem> qualificationItems)
+            Domain.ImportTypes.QualificationItem qualificationItem)
         {
             //Arrange
             var response = new HttpResponseMessage
             {
-                Content = new StringContent(JsonConvert.SerializeObject(qualificationItems)),
+                Content = new StringContent(JsonConvert.SerializeObject(qualificationItem)),
                 StatusCode = HttpStatusCode.Accepted
             };
             var httpMessageHandler = MessageHandler.SetupMessageHandlerMock(response, new Uri($"{Constants.QualificationSectorSubjectAreaUrl}items/{itemHash}"));
@@ -68,7 +68,7 @@ namespace SFA.DAS.Courses.Infrastructure.UnitTests.Api
             var actual = await apprenticeshipService.GetEntry(itemHash);
             
             //Assert
-            actual.Should().BeEquivalentTo(qualificationItems);
+            actual.Should().BeEquivalentTo(qualificationItem);
             httpMessageHandler.Protected()
                 .Verify<Task<HttpResponseMessage>>(
                     "SendAsync",Times.Once(),

--- a/src/SFA.DAS.Courses.Infrastructure.UnitTests/Api/WhenGettingDataFromQualificationSectorSubjectAreaApi.cs
+++ b/src/SFA.DAS.Courses.Infrastructure.UnitTests/Api/WhenGettingDataFromQualificationSectorSubjectAreaApi.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SFA.DAS.Courses.Domain.Configuration;
+using SFA.DAS.Courses.Infrastructure.Api;
+
+namespace SFA.DAS.Courses.Infrastructure.UnitTests.Api
+{
+    public class WhenGettingDataFromQualificationSectorSubjectAreaApi
+    {
+        [Test, AutoData]
+        public async Task Then_The_Endpoint_Is_Called_And_An_Item_Array_Is_Returned(
+            List<Domain.ImportTypes.QualificationItemList> qualificationItemList)
+        {
+            //Arrange
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(qualificationItemList)),
+                StatusCode = HttpStatusCode.Accepted
+            };
+            var httpMessageHandler = MessageHandler.SetupMessageHandlerMock(response, new Uri($"{Constants.QualificationSectorSubjectAreaUrl}entries/"));
+            var client = new HttpClient(httpMessageHandler.Object);
+            var apprenticeshipService = new QualificationSectorSubjectAreaService(client);
+            
+            //Act
+            var actual = await apprenticeshipService.GetEntries();
+            
+            //Assert
+            actual.Should().BeEquivalentTo(qualificationItemList);
+            httpMessageHandler.Protected()
+                .Verify<Task<HttpResponseMessage>>(
+                    "SendAsync",Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(c =>
+                        c.Method.Equals(HttpMethod.Get)
+                        && c.Headers.Contains("Accept")
+                        && c.Headers.GetValues("Accept").Single().Equals("application/json")
+                    ),
+                    ItExpr.IsAny<CancellationToken>()
+                );
+        }
+        
+        [Test, AutoData]
+        public async Task Then_The_Endpoint_Is_Called_And_An_Item_Detail_Is_Returned(
+            string itemHash,
+            List<Domain.ImportTypes.QualificationItem> qualificationItems)
+        {
+            //Arrange
+            var response = new HttpResponseMessage
+            {
+                Content = new StringContent(JsonConvert.SerializeObject(qualificationItems)),
+                StatusCode = HttpStatusCode.Accepted
+            };
+            var httpMessageHandler = MessageHandler.SetupMessageHandlerMock(response, new Uri($"{Constants.QualificationSectorSubjectAreaUrl}items/{itemHash}"));
+            var client = new HttpClient(httpMessageHandler.Object);
+            var apprenticeshipService = new QualificationSectorSubjectAreaService(client);
+            
+            //Act
+            var actual = await apprenticeshipService.GetEntry(itemHash);
+            
+            //Assert
+            actual.Should().BeEquivalentTo(qualificationItems);
+            httpMessageHandler.Protected()
+                .Verify<Task<HttpResponseMessage>>(
+                    "SendAsync",Times.Once(),
+                    ItExpr.Is<HttpRequestMessage>(c =>
+                        c.Method.Equals(HttpMethod.Get)
+                        && c.Headers.Contains("Accept")
+                        && c.Headers.GetValues("Accept").Single().Equals("application/json")
+                    ),
+                    ItExpr.IsAny<CancellationToken>()
+                );
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Infrastructure/Api/DataDownloadService.cs
+++ b/src/SFA.DAS.Courses.Infrastructure/Api/DataDownloadService.cs
@@ -5,11 +5,11 @@ using SFA.DAS.Courses.Domain.Interfaces;
 
 namespace SFA.DAS.Courses.Infrastructure.Api
 {
-    public class LarsDataDownloadService : ILarsDataDownloadService
+    public class DataDownloadService : IDataDownloadService
     {
         private readonly HttpClient _client;
 
-        public LarsDataDownloadService (HttpClient client)
+        public DataDownloadService (HttpClient client)
         {
             _client = client;
         }

--- a/src/SFA.DAS.Courses.Infrastructure/Api/QualificationSectorSubjectAreaService.cs
+++ b/src/SFA.DAS.Courses.Infrastructure/Api/QualificationSectorSubjectAreaService.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SFA.DAS.Courses.Domain.Configuration;
+using SFA.DAS.Courses.Domain.ImportTypes;
+using SFA.DAS.Courses.Domain.Interfaces;
+
+namespace SFA.DAS.Courses.Infrastructure.Api
+{
+    public class QualificationSectorSubjectAreaService : IQualificationSectorSubjectAreaService
+    {
+        private readonly HttpClient _client;
+
+        public QualificationSectorSubjectAreaService (HttpClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<IEnumerable<QualificationItem>> GetEntry(string itemHash)
+        {
+            AddHeader();
+            var response =  await _client.GetAsync($"{Constants.QualificationSectorSubjectAreaUrl}items/{itemHash}");
+            
+            response.EnsureSuccessStatusCode();
+            
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<QualificationItem>>(jsonResponse);
+        }
+
+        public async Task<IEnumerable<QualificationItemList>> GetEntries()
+        {
+            AddHeader();
+            var response = await _client.GetAsync($"{Constants.QualificationSectorSubjectAreaUrl}entries/");
+            
+            response.EnsureSuccessStatusCode();
+            
+            var jsonResponse = await response.Content.ReadAsStringAsync();
+            return JsonConvert.DeserializeObject<List<QualificationItemList>>(jsonResponse);
+        }
+
+        private void AddHeader()
+        {
+            _client.DefaultRequestHeaders.Remove("Accept");
+            _client.DefaultRequestHeaders.Add("Accept", "application/json");
+        }
+    }
+}

--- a/src/SFA.DAS.Courses.Infrastructure/Api/QualificationSectorSubjectAreaService.cs
+++ b/src/SFA.DAS.Courses.Infrastructure/Api/QualificationSectorSubjectAreaService.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.Courses.Infrastructure.Api
             _client = client;
         }
 
-        public async Task<IEnumerable<QualificationItem>> GetEntry(string itemHash)
+        public async Task<QualificationItem> GetEntry(string itemHash)
         {
             AddHeader();
             var response =  await _client.GetAsync($"{Constants.QualificationSectorSubjectAreaUrl}items/{itemHash}");
@@ -25,7 +25,7 @@ namespace SFA.DAS.Courses.Infrastructure.Api
             response.EnsureSuccessStatusCode();
             
             var jsonResponse = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<QualificationItem>>(jsonResponse);
+            return JsonConvert.DeserializeObject<QualificationItem>(jsonResponse);
         }
 
         public async Task<IEnumerable<QualificationItemList>> GetEntries()


### PR DESCRIPTION
Added achievement rate data - first part is to get LARS data of SectorSubjectAreaTier2 and update LARS Standard to return the id and description. The intermediary step of loading the names from: 

**https://www.registers.service.gov.uk/registers/qualification-sector-subject-area** 

has been removed for now as the data is identical. Also running this slows the import process down. If it is required at a later stage then the last commit can be reverted to re-enable fetching the data.