### PR TITLE
SV-369 update standards id endpoint

### DIFF
--- a/src/SFA.DAS.Courses.Api.AcceptanceTests/Features/Standards.feature
+++ b/src/SFA.DAS.Courses.Api.AcceptanceTests/Features/Standards.feature
@@ -94,5 +94,13 @@ Scenario: Get list of active and available standards
     When I GET the following url: /api/courses/standards?filter=NotYetApproved
     Then an http status code of 200 is returned
     And all not yet approved standards are returned
+
+    Scenario: Get latest version of a standard by Lars Code
+	Given I have an http client
+    When I GET the following url: /api/courses/standards/1
+    Then an http status code of 200 is returned
+    And the following valid individual standard is returned
+    | title                            | level | sector                        | version | status                |
+    | Head Brewer                      | 2     | Engineering and manufacturing | 1.3     | Approved for delivery |
     
     

--- a/src/SFA.DAS.Courses.Api.AcceptanceTests/Steps/StandardsSteps.cs
+++ b/src/SFA.DAS.Courses.Api.AcceptanceTests/Steps/StandardsSteps.cs
@@ -156,6 +156,30 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Steps
             );
         }
 
+        [Then("the following valid individual standard is returned")]
+        public async Task ThenTheFollowingValidIndividualStandardIsReturned(Table table)
+        {
+            if (!_context.TryGetValue<HttpResponseMessage>(ContextKeys.HttpResponse, out var result))
+            {
+                Assert.Fail($"scenario context does not contain value for key [{ContextKeys.HttpResponse}]");
+            }
+
+            var standard = await HttpUtilities.ReadContent<GetStandardResponse>(result.Content);
+
+            standard.Should().BeEquivalentTo(
+                GetExpected(table).Single(), options => options
+                    .Excluding(std => std. Sector)
+                    .Excluding(std => std.ApprenticeshipFunding)
+                    .Excluding(std => std.LarsStandard)
+                    .Excluding(std => std.RouteId)
+                    .Excluding(std => std.SearchScore)
+                    .Excluding(std => std.RegulatedBody)
+                    .Excluding(std => std.Duties)
+                    .Excluding(std => std.CoreAndOptions)
+                    .Excluding(std => std.CoreDuties)
+            );
+        }
+
         private IEnumerable<Standard> GetExpected(Table table)
         {
             var existingSectors = DbUtilities.GetTestSectors();

--- a/src/SFA.DAS.Courses.Api.AcceptanceTests/Steps/StandardsSteps.cs
+++ b/src/SFA.DAS.Courses.Api.AcceptanceTests/Steps/StandardsSteps.cs
@@ -168,7 +168,7 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Steps
 
             standard.Should().BeEquivalentTo(
                 GetExpected(table).Single(), options => options
-                    .Excluding(std => std. Sector)
+                    .Excluding(std => std.Sector)
                     .Excluding(std => std.ApprenticeshipFunding)
                     .Excluding(std => std.LarsStandard)
                     .Excluding(std => std.RouteId)

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandard.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandard.cs
@@ -19,7 +19,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
     {
         [Test, MoqAutoData]
         public async Task Then_Gets_Standards_List_From_Mediator(
-            int standardId,
+            int larsCode,
             GetStandardResult queryResult,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy] StandardsController controller)
@@ -30,7 +30,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(queryResult);
 
-            var controllerResult = await controller.Get(standardId) as ObjectResult;
+            var controllerResult = await controller.Get(larsCode) as ObjectResult;
 
             var model = controllerResult.Value as GetStandardResponse;
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
@@ -39,7 +39,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
 
         [Test, MoqAutoData]
         public async Task And_Exception_Then_Returns_Not_Found(
-            int standardId,
+            int larsCode,
             [Frozen] Mock<IMediator> mockMediator,
             [Greedy] StandardsController controller)
         {
@@ -49,7 +49,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
                     It.IsAny<CancellationToken>()))
                 .Throws<InvalidOperationException>();
 
-            var controllerResult = await controller.Get(standardId) as StatusCodeResult;
+            var controllerResult = await controller.Get(larsCode) as StatusCodeResult;
 
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.NotFound);
         }

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandard.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandard.cs
@@ -18,7 +18,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
     public class WhenCallingGetStandard
     {
         [Test, MoqAutoData]
-        public async Task Then_Gets_Standards_List_From_Mediator(
+        public async Task Then_Gets_Standard_From_Mediator(
             int larsCode,
             GetStandardResult queryResult,
             [Frozen] Mock<IMediator> mockMediator,

--- a/src/SFA.DAS.Courses.Api/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Courses.Api/Controllers/StandardsController.cs
@@ -64,12 +64,12 @@ namespace SFA.DAS.Courses.Api.Controllers
         }
 
         [HttpGet]
-        [Route("{id}")]
-        public async Task<IActionResult> Get(int id)
+        [Route("{larsCode}")]
+        public async Task<IActionResult> Get(int larsCode)
         {
             try
             {
-                var result = await _mediator.Send(new GetStandardQuery {LarsCode = id});
+                var result = await _mediator.Send(new GetStandardQuery {LarsCode = larsCode});
 
                 var response = (GetStandardResponse)result.Standard;
 
@@ -77,7 +77,7 @@ namespace SFA.DAS.Courses.Api.Controllers
             }
             catch (InvalidOperationException e)
             {
-                _logger.LogError(e, $"Standard not found {id}");
+                _logger.LogError(e, $"Standard not found {larsCode}");
                 return NotFound();
             }
         }

--- a/src/SFA.DAS.Courses.Api/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Courses.Api/Controllers/StandardsController.cs
@@ -69,7 +69,7 @@ namespace SFA.DAS.Courses.Api.Controllers
         {
             try
             {
-                var result = await _mediator.Send(new GetStandardQuery {StandardId = id});
+                var result = await _mediator.Send(new GetStandardQuery {LarsCode = id});
 
                 var response = (GetStandardResponse)result.Standard;
 

--- a/src/SFA.DAS.Courses.Application.UnitTests/Courses/Queries/WhenGettingAStandard.cs
+++ b/src/SFA.DAS.Courses.Application.UnitTests/Courses/Queries/WhenGettingAStandard.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.Courses.Application.UnitTests.Courses.Queries
             GetStandardQueryHandler handler)
         {
             mockStandardsService
-                .Setup(service => service.GetStandard(query.StandardId))
+                .Setup(service => service.GetStandard(query.LarsCode))
                 .ReturnsAsync(standardsFromService);
 
             var result = await handler.Handle(query, CancellationToken.None);

--- a/src/SFA.DAS.Courses.Application.UnitTests/Courses/Services/WhenGettingAStandard.cs
+++ b/src/SFA.DAS.Courses.Application.UnitTests/Courses/Services/WhenGettingAStandard.cs
@@ -16,16 +16,16 @@ namespace SFA.DAS.Courses.Application.UnitTests.Courses.Services
     {
         [Test, RecursiveMoqAutoData]
         public async Task Then_Gets_A_Standard_From_The_Repository(
-            int standardId,
+            int larsCode,
             Standard standardFromRepo,
             [Frozen] Mock<IStandardRepository> mockStandardsRepository,
             StandardsService service)
         {
             mockStandardsRepository
-                .Setup(repository => repository.Get(standardId))
+                .Setup(repository => repository.Get(larsCode))
                 .ReturnsAsync(standardFromRepo);
 
-            var standard = await service.GetStandard(standardId);
+            var standard = await service.GetStandard(larsCode);
 
             standard.Should().BeEquivalentTo(standardFromRepo, options=> options
                 .Excluding(c=>c.ApprenticeshipFunding)

--- a/src/SFA.DAS.Courses.Application/Courses/Queries/GetStandard/GetStandardQuery.cs
+++ b/src/SFA.DAS.Courses.Application/Courses/Queries/GetStandard/GetStandardQuery.cs
@@ -1,9 +1,9 @@
-using MediatR;
+﻿using MediatR;
 
 namespace SFA.DAS.Courses.Application.Courses.Queries.GetStandard
 {
     public class GetStandardQuery : IRequest<GetStandardResult>
     {
-        public int StandardId { get ; set ; }
+        public int LarsCode { get ; set ; }
     }
 }

--- a/src/SFA.DAS.Courses.Application/Courses/Queries/GetStandard/GetStandardQueryHandler.cs
+++ b/src/SFA.DAS.Courses.Application/Courses/Queries/GetStandard/GetStandardQueryHandler.cs
@@ -1,4 +1,4 @@
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using SFA.DAS.Courses.Domain.Interfaces;
@@ -15,7 +15,7 @@ namespace SFA.DAS.Courses.Application.Courses.Queries.GetStandard
         }
         public async Task<GetStandardResult> Handle(GetStandardQuery request, CancellationToken cancellationToken)
         {
-            var standard = await _standardsService.GetStandard(request.StandardId);
+            var standard = await _standardsService.GetStandard(request.LarsCode);
             
             return new GetStandardResult { Standard = standard };
         }

--- a/src/SFA.DAS.Courses.Application/Courses/Services/StandardsService.cs
+++ b/src/SFA.DAS.Courses.Application/Courses/Services/StandardsService.cs
@@ -49,9 +49,9 @@ namespace SFA.DAS.Courses.Application.Courses.Services
             return count;
         }
 
-        public async Task<Standard> GetStandard(int standardId)
+        public async Task<Standard> GetStandard(int larsCode)
         {
-            var standard = await _standardsRepository.Get(standardId);
+            var standard = await _standardsRepository.Get(larsCode);
 
             return (Standard)standard;
         }

--- a/src/SFA.DAS.Courses.Data.UnitTests/Repository/StandardRepository/WhenGettingAStandard.cs
+++ b/src/SFA.DAS.Courses.Data.UnitTests/Repository/StandardRepository/WhenGettingAStandard.cs
@@ -17,20 +17,62 @@ namespace SFA.DAS.Courses.Data.UnitTests.Repository.StandardRepository
         private Mock<ICoursesDataContext> _coursesDataContext;
         private List<Standard> _standards;
         private Data.Repository.StandardRepository _standardRepository;
-        private const int ExpectedStandardId = 2;
+        private const string ExpectedStandardUId = "ST002_1.2";
+        private const int ExpectedLarsCode = 2;
 
         [SetUp]
         public void Arrange()
         {
+            // same standard with lars code, on retired and two active
             _standards = new List<Standard>
             {
                 new Standard()
                 {
-                    LarsCode = 1
+                    IfateReferenceNumber = "ST001",
+                    StandardUId = "ST001_1.0",
+                    LarsCode = 1,
+                    Status = "Approved for delivery",
+                    Version = 1.0m,
+                    LarsStandard = new LarsStandard
+                    {
+                        LarsCode = 1
+                    }
                 },
                 new Standard
                 {
-                    LarsCode = ExpectedStandardId
+                    IfateReferenceNumber = "ST002",
+                    StandardUId = "ST002_1.1",
+                    LarsCode = 2,
+                    Status = "Approved for delivery",
+                    Version = 1.1m,
+                    LarsStandard = new LarsStandard
+                    {
+                        LarsCode = 2
+                    }
+                },
+                new Standard
+                {
+                    IfateReferenceNumber = "ST002",
+                    StandardUId = ExpectedStandardUId,
+                    LarsCode = 2,
+                    Status = "Approved for delivery",
+                    Version = 1.2m,
+                    LarsStandard = new LarsStandard
+                    {
+                        LarsCode = 2
+                    }
+                },
+                new Standard
+                {
+                    IfateReferenceNumber = "ST002",
+                    StandardUId = "ST002_1.0",
+                    LarsCode = 2,
+                    Status = "Retired",
+                    Version = 1.0m,
+                    LarsStandard = new LarsStandard
+                    {
+                        LarsCode = 2
+                    }
                 }
             };
             
@@ -41,14 +83,14 @@ namespace SFA.DAS.Courses.Data.UnitTests.Repository.StandardRepository
         }
 
         [Test]
-        public async Task Then_The_Standard_Is_Returned_By_Id()
+        public async Task Then_The_Standard_Is_Returned_By_LarsCode()
         {
             //Act
-            var standards = await _standardRepository.Get(ExpectedStandardId);
+            var standards = await _standardRepository.Get(ExpectedLarsCode);
             
             //Assert
             Assert.IsNotNull(standards);
-            standards.Should().BeEquivalentTo(_standards.SingleOrDefault(c=>c.LarsCode.Equals(ExpectedStandardId)));
+            standards.Should().BeEquivalentTo(_standards.SingleOrDefault(c=>c.StandardUId.Equals(ExpectedStandardUId)));
         }
         
         [Test]
@@ -58,7 +100,7 @@ namespace SFA.DAS.Courses.Data.UnitTests.Repository.StandardRepository
             _coursesDataContext.Setup(x => x.Standards).ReturnsDbSet(new List<Standard>());
             
             //Act Assert
-            Assert.ThrowsAsync<InvalidOperationException>(() => _standardRepository.Get(ExpectedStandardId));
+            Assert.ThrowsAsync<InvalidOperationException>(() => _standardRepository.Get(ExpectedLarsCode));
         }
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Interfaces/IStandardRepository.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/IStandardRepository.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.Courses.Domain.Interfaces
         Task<int> Count(StandardFilter filter);
         void DeleteAll();
         Task InsertMany(IEnumerable<Standard> standards);
-        Task<Standard> Get(int id);
+        Task<Standard> Get(int larsCode);
         Task<IEnumerable<Standard>> GetStandards(IList<Guid> routeIds, IList<int> levels, StandardFilter filter);
     }
 }

--- a/src/SFA.DAS.Courses.Domain/Interfaces/IStandardsService.cs
+++ b/src/SFA.DAS.Courses.Domain/Interfaces/IStandardsService.cs
@@ -10,6 +10,6 @@ namespace SFA.DAS.Courses.Domain.Interfaces
     {
         Task<IEnumerable<Standard>> GetStandardsList(string keyword, IList<Guid> routeIds, IList<int> levels, OrderBy orderBy, StandardFilter filter);
         Task<int> Count(StandardFilter filter);
-        Task<Standard> GetStandard(int standardId);
+        Task<Standard> GetStandard(int larsCode);
     }
 }


### PR DESCRIPTION
Standards Get By Id endpoint broken due to now having multiple versions for a given Lars Code. This updates it to be backward compatible but does have the problem of IsLatestVersion being in memory filtering so will also be looked at in ticket SV-401