### PR TITLE
SV-470 limit data from existing end points

### DIFF
--- a/src/SFA.DAS.Courses.Api.AcceptanceTests/Steps/StandardsSteps.cs
+++ b/src/SFA.DAS.Courses.Api.AcceptanceTests/Steps/StandardsSteps.cs
@@ -156,6 +156,9 @@ namespace SFA.DAS.Courses.Api.AcceptanceTests.Steps
                 .Excluding(c => c.EqaProviderContactEmail)
                 .Excluding(c => c.EqaProviderContactName)
                 .Excluding(c => c.EqaProviderName)
-                .Excluding(c => c.EqaProviderWebLink);
+                .Excluding(c => c.EqaProviderWebLink)
+                .Excluding(c => c.AssessmentPlanUrl)
+                .Excluding(c => c.TrailBlazerContact)
+                .Excluding(c => c.Options);
     }
 }

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/StandardToGetStandardResponseOptions.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/StandardToGetStandardResponseOptions.cs
@@ -1,0 +1,14 @@
+﻿using FluentAssertions.Equivalency;
+
+namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
+{
+    public static class StandardToGetStandardResponseOptions
+    {
+        public static EquivalencyAssertionOptions<Domain.Courses.Standard> Exclusions(EquivalencyAssertionOptions<Domain.Courses.Standard> config) => config
+            .Excluding(s => s.AssessmentPlanUrl)
+            .Excluding(s => s.VersionDetail)
+            .Excluding(s => s.EqaProvider)
+            .Excluding(s => s.Options)
+            .Excluding(s => s.TrailBlazerContact);
+    }
+}

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandard.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandard.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
 
             var model = controllerResult.Value as GetStandardResponse;
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
-            model.Should().BeEquivalentTo(queryResult.Standard);
+            model.Should().BeEquivalentTo(queryResult.Standard, StandardToGetStandardResponseOptions.Exclusions);
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardByStandardUId.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardByStandardUId.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
 
             var model = controllerResult.Value as GetStandardResponse;
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
-            model.Should().BeEquivalentTo(queryResult.Standard);
+            model.Should().BeEquivalentTo(queryResult.Standard, StandardToGetStandardResponseOptions.Exclusions);
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardByStandardUId.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardByStandardUId.cs
@@ -32,7 +32,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
 
             var controllerResult = await controller.Get(standardUId) as ObjectResult;
 
-            var model = controllerResult.Value as GetStandardResponse;
+            var model = controllerResult.Value as GetStandardDetailResponse;
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
             model.Should().BeEquivalentTo(queryResult.Standard, StandardToGetStandardResponseOptions.Exclusions);
         }

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardsByIFateReferenceNumber.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardsByIFateReferenceNumber.cs
@@ -35,7 +35,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
 
             var model = controllerResult.Value as GetStandardVersionsListResponse;
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
-            model.Standards.Should().BeEquivalentTo(queryResult.Standards);
+            model.Standards.Should().BeEquivalentTo(queryResult.Standards, StandardToGetStandardResponseOptions.Exclusions);
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardsList.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Controllers/Standards/WhenCallingGetStandardsList.cs
@@ -46,7 +46,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Controllers.Standards
 
             var model = controllerResult.Value as GetStandardsListResponse;
             controllerResult.StatusCode.Should().Be((int)HttpStatusCode.OK);
-            model.Standards.Should().BeEquivalentTo(queryResult.Standards);
+            model.Standards.Should().BeEquivalentTo(queryResult.Standards, StandardToGetStandardResponseOptions.Exclusions);
             model.Total.Should().Be(queryResult.Total);
             model.TotalFiltered.Should().Be(queryResult.TotalFiltered);
         }

--- a/src/SFA.DAS.Courses.Api.UnitTests/Models/WhenCastingToGetStandardResponseFromDomainType.cs
+++ b/src/SFA.DAS.Courses.Api.UnitTests/Models/WhenCastingToGetStandardResponseFromDomainType.cs
@@ -2,6 +2,7 @@
 using FluentAssertions;
 using NUnit.Framework;
 using SFA.DAS.Courses.Api.ApiResponses;
+using SFA.DAS.Courses.Api.UnitTests.Controllers.Standards;
 using SFA.DAS.Courses.Domain.Courses;
 
 namespace SFA.DAS.Courses.Api.UnitTests.Models
@@ -14,7 +15,7 @@ namespace SFA.DAS.Courses.Api.UnitTests.Models
         {
             var response = (GetStandardResponse)source;
 
-            response.Should().BeEquivalentTo(source);
+            response.Should().BeEquivalentTo(source, StandardToGetStandardResponseOptions.Exclusions);
         }
     }
 }

--- a/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardDetailResponse.cs
+++ b/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardDetailResponse.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using SFA.DAS.Courses.Domain.Courses;
+
+namespace SFA.DAS.Courses.Api.ApiResponses
+{
+    public class GetStandardDetailResponse
+    {
+        public string StandardUId { get; set; }
+        public string IfateReferenceNumber { get; set; }
+        public int LarsCode { get; set; }
+        public string Status { get; set; }
+        public float? SearchScore { get; set; }
+        public string Title { get; set; }
+        public int Level { get; set; }
+        public decimal Version { get; set; }
+        public string OverviewOfRole { get; set; }
+        public string Keywords { get; set; }
+        public string Route { get; set; }
+        public string AssessmentPlanUrl { get; set; }
+        public string TrailBlazerContact { get; set; }
+        public string TypicalJobTitles { get; set; }
+        public string CoreSkillsCount { get; set; }
+        public List<string> Skills { get; set; }
+        public List<string> Knowledge { get; set; }
+        public List<string> Behaviours { get; set; }
+        public string StandardPageUrl { get; set; }
+        public string IntegratedDegree { get; set; }
+        public decimal SectorSubjectAreaTier2 { get ; set ; }
+        public string SectorSubjectAreaTier2Description { get ; set ; }
+
+        public List<ApprenticeshipFundingResponse> ApprenticeshipFunding { get ; set ; }
+
+        public StandardDatesResponse StandardDates { get ; set ; }
+
+        public StandardVersionDetailResponse VersionDetail { get; set; }
+
+        public EqaProviderResponse EqaProvider { get; set; }
+
+        public bool OtherBodyApprovalRequired { get; set; }
+        public string ApprovalBody { get; set; }
+        public List<string> Duties { get; set; }
+        public bool CoreAndOptions { get; set; }
+        public string CoreDuties { get; set; }
+        public bool IntegratedApprenticeship { get ; set ; }
+        public List<string> Options { get; set; }
+
+        public static implicit operator GetStandardDetailResponse(Standard source)
+        {
+            return new GetStandardDetailResponse
+            {
+                StandardUId = source.StandardUId,
+                IfateReferenceNumber = source.IfateReferenceNumber,
+                LarsCode = source.LarsCode,
+                Status = source.Status,
+                SearchScore = source.SearchScore,
+                Title = source.Title,
+                Level = source.Level,
+                Version = source.Version,
+                OverviewOfRole = source.OverviewOfRole,
+                Keywords = source.Keywords,
+                Route = source.Route,
+                AssessmentPlanUrl = source.AssessmentPlanUrl,
+                TrailBlazerContact = source.TrailBlazerContact,
+                TypicalJobTitles = source.TypicalJobTitles,
+                CoreSkillsCount = source.CoreSkillsCount,
+                Skills = source.Skills,
+                Knowledge = source.Knowledge,
+                Behaviours = source.Behaviours,
+                StandardPageUrl = source.StandardPageUrl,
+                IntegratedDegree = source.IntegratedDegree,
+                ApprenticeshipFunding = source.ApprenticeshipFunding.Select(c=>(ApprenticeshipFundingResponse)c).ToList(),
+                StandardDates = (StandardDatesResponse)source.StandardDates,
+                VersionDetail = (StandardVersionDetailResponse) source.VersionDetail,
+                EqaProvider = (EqaProviderResponse) source.EqaProvider,
+                SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
+                SectorSubjectAreaTier2Description = source.SectorSubjectAreaTier2Description,
+                OtherBodyApprovalRequired = source.OtherBodyApprovalRequired,
+                ApprovalBody = source.ApprovalBody,
+                Duties = source.Duties,
+                CoreAndOptions = source.CoreAndOptions,
+                CoreDuties = source.CoreDuties,
+                IntegratedApprenticeship = source.IntegratedApprenticeship,
+                Options = source.Options
+            };
+        }
+    }
+}
+

--- a/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardResponse.cs
+++ b/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardResponse.cs
@@ -17,8 +17,6 @@ namespace SFA.DAS.Courses.Api.ApiResponses
         public string OverviewOfRole { get; set; }
         public string Keywords { get; set; }
         public string Route { get; set; }
-        public string AssessmentPlanUrl { get; set; }
-        public string TrailBlazerContact { get; set; }
         public string TypicalJobTitles { get; set; }
         public string CoreSkillsCount { get; set; }
         public List<string> Skills { get; set; }
@@ -33,17 +31,12 @@ namespace SFA.DAS.Courses.Api.ApiResponses
 
         public StandardDatesResponse StandardDates { get ; set ; }
 
-        public StandardVersionDetailResponse VersionDetail { get; set; }
-
-        public EqaProviderResponse EqaProvider { get; set; }
-
         public bool OtherBodyApprovalRequired { get; set; }
         public string ApprovalBody { get; set; }
         public List<string> Duties { get; set; }
         public bool CoreAndOptions { get; set; }
         public string CoreDuties { get; set; }
         public bool IntegratedApprenticeship { get ; set ; }
-        public List<string> Options { get; set; }
 
         public static implicit operator GetStandardResponse(Standard source)
         {
@@ -60,8 +53,6 @@ namespace SFA.DAS.Courses.Api.ApiResponses
                 OverviewOfRole = source.OverviewOfRole,
                 Keywords = source.Keywords,
                 Route = source.Route,
-                AssessmentPlanUrl = source.AssessmentPlanUrl,
-                TrailBlazerContact = source.TrailBlazerContact,
                 TypicalJobTitles = source.TypicalJobTitles,
                 CoreSkillsCount = source.CoreSkillsCount,
                 Skills = source.Skills,
@@ -71,8 +62,6 @@ namespace SFA.DAS.Courses.Api.ApiResponses
                 IntegratedDegree = source.IntegratedDegree,
                 ApprenticeshipFunding = source.ApprenticeshipFunding.Select(c=>(ApprenticeshipFundingResponse)c).ToList(),
                 StandardDates = (StandardDatesResponse)source.StandardDates,
-                VersionDetail = (StandardVersionDetailResponse) source.VersionDetail,
-                EqaProvider = (EqaProviderResponse) source.EqaProvider,
                 SectorSubjectAreaTier2 = source.SectorSubjectAreaTier2,
                 SectorSubjectAreaTier2Description = source.SectorSubjectAreaTier2Description,
                 OtherBodyApprovalRequired = source.OtherBodyApprovalRequired,
@@ -80,8 +69,7 @@ namespace SFA.DAS.Courses.Api.ApiResponses
                 Duties = source.Duties,
                 CoreAndOptions = source.CoreAndOptions,
                 CoreDuties = source.CoreDuties,
-                IntegratedApprenticeship = source.IntegratedApprenticeship,
-                Options = source.Options
+                IntegratedApprenticeship = source.IntegratedApprenticeship
             };
         }
     }

--- a/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardVersionsListResponse.cs
+++ b/src/SFA.DAS.Courses.Api/ApiResponses/GetStandardVersionsListResponse.cs
@@ -4,6 +4,6 @@ namespace SFA.DAS.Courses.Api.ApiResponses
 {
     public class GetStandardVersionsListResponse
     {
-        public IEnumerable<GetStandardResponse> Standards { get; set; }
+        public IEnumerable<GetStandardDetailResponse> Standards { get; set; }
     }
 }

--- a/src/SFA.DAS.Courses.Api/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Courses.Api/Controllers/StandardsController.cs
@@ -90,7 +90,7 @@ namespace SFA.DAS.Courses.Api.Controllers
             {
                 var result = await _mediator.Send(new GetStandardByStandardUIdQuery { StandardUId = standardUId });
 
-                var response = (GetStandardResponse)result.Standard;
+                var response = (GetStandardDetailResponse)result.Standard;
 
                 return Ok(response);
             }
@@ -111,7 +111,7 @@ namespace SFA.DAS.Courses.Api.Controllers
 
                 var response = new GetStandardVersionsListResponse
                 {
-                    Standards = queryResult.Standards.Select(standard => (GetStandardResponse)standard)
+                    Standards = queryResult.Standards.Select(standard => (GetStandardDetailResponse)standard)
                 };
 
                 return Ok(response);


### PR DESCRIPTION
I have changed the response endpoints to be specific. `GetStandardResponse` was changed to have only added essential fields. `GetList` and `GetByLarsCode` will return this response. 

I have added new `GetStandardDetailResponse` which has all fields from `GetStandardResponse` and more. 

I have kept the service and repository unchanged. 