### PR TITLE
FAT2-424 - Enable retry on failure for DBContext

### DIFF
--- a/src/SFA.DAS.Courses.Data/CoursesDataContext.cs
+++ b/src/SFA.DAS.Courses.Data/CoursesDataContext.cs
@@ -78,9 +78,15 @@ namespace SFA.DAS.Courses.Data
             var connection = new SqlConnection
             {
                 ConnectionString = _configuration.ConnectionString,
-                AccessToken = _azureServiceTokenProvider.GetAccessTokenAsync(AzureResource).Result
+                AccessToken = _azureServiceTokenProvider.GetAccessTokenAsync(AzureResource).Result,
             };
-            optionsBuilder.UseSqlServer(connection);
+            
+            optionsBuilder.UseSqlServer(connection,options=>
+                options.EnableRetryOnFailure(
+                    5,
+                    TimeSpan.FromSeconds(20),
+                    null
+                ));
 
         }
 


### PR DESCRIPTION
This will only be enabled when using managed identity connection