### PR TITLE
Changed from ContinuousDeployment to Mainline

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-mode: ContinuousDeployment
+mode: Mainline


### PR DESCRIPTION
Switch GitVersion mode from ContinuousDeployment to Mainline so prerelease numbers no longer depend on commit height. Mainline automatically increments versions on each merge, ensuring we always generate a new NuGet version instead of reusing the same one